### PR TITLE
feat: Add child lock switch support for AC4236

### DIFF
--- a/custom_components/philips_airpurifier_coap/philips.py
+++ b/custom_components/philips_airpurifier_coap/philips.py
@@ -872,6 +872,7 @@ class PhilipsAC4236(PhilipsGenericCoAPFan):
         SPEED_2: {PHILIPS_POWER: "1", PHILIPS_MODE: "M", PHILIPS_SPEED: "2"},
         PRESET_MODE_TURBO: {PHILIPS_POWER: "1", PHILIPS_MODE: "T", PHILIPS_SPEED: "t"},
     }
+    AVAILABLE_SWITCHES = [PHILIPS_CHILD_LOCK]
 
 
 class PhilipsAC4558(PhilipsGenericCoAPFan):


### PR DESCRIPTION
The AC4236 does have a child lock switch. I added it to `PhilipsAC4236` and tested it successfully with my device.