### PR TITLE
Allow user to adjust brightness on AMF/CX

### DIFF
--- a/custom_components/philips_airpurifier_coap/const.py
+++ b/custom_components/philips_airpurifier_coap/const.py
@@ -521,6 +521,7 @@ LIGHT_TYPES: dict[str, LightDescription] = {
         CONF_ENTITY_CATEGORY: EntityCategory.CONFIG,
         SWITCH_ON: 100,
         SWITCH_OFF: 0,
+        DIMMABLE: True,
     },
 }
 


### PR DESCRIPTION
The display is dimmable. Tested and confirmed working.
![image](https://github.com/kongo09/philips-airpurifier-coap/assets/1294876/2fa80e5c-9991-4a9d-9a28-45d8a0dd81e7)
Syncs both ways between HA and the Philips app.