### PR TITLE
Fix pre-filter constant

### DIFF
--- a/custom_components/philips_airpurifier_coap/const.py
+++ b/custom_components/philips_airpurifier_coap/const.py
@@ -538,7 +538,7 @@ FILTER_TYPES: dict[str, FilterDescription] = {
             10: ICON.NANOPROTECT_FILTER,
         },
         FanAttributes.LABEL: FanAttributes.FILTER_NANOPROTECT_CLEAN,
-        FanAttributes.TOTAL: PhilipsApi.NEW2_FILTER_NANOPROTECT_CLEAN_TOTAL,
+        FanAttributes.TOTAL: PhilipsApi.NEW2_FILTER_NANOPROTECT_PREFILTER_TOTAL,
         FanAttributes.TYPE: "",
     },
 }


### PR DESCRIPTION
Had issues in beta 6 as reported here: https://github.com/kongo09/philips-airpurifier-coap/issues/63#issuecomment-1886007955
New sensors work now, but I notice missing icons for multiple entities.
![image](https://github.com/kongo09/philips-airpurifier-coap/assets/1294876/b04590f9-a391-4dcd-81f7-4114c9b3b667)

