### PR TITLE
Associate icons with fan preset_mode

### DIFF
--- a/custom_components/philips_airpurifier_coap/icons.json
+++ b/custom_components/philips_airpurifier_coap/icons.json
@@ -1,0 +1,41 @@
+{
+  "entity": {
+    "fan": {
+      "philips_generic_fan": {
+        "state_attributes": {
+          "preset_mode": {
+            "default": "mdi:circle-small",
+            "state": {
+              "speed 1": "pap:speed_1",
+              "gentle/speed 1": "pap:speed_1",
+              "speed 2": "pap:speed_2",
+              "speed 3": "pap:speed_3",
+              "speed 4": "mdi:numeric-4-circle-outline",
+              "speed 5": "mdi:numeric-5-circle-outline",
+              "speed 6": "mdi:numeric-6-circle-outline",
+              "speed 7": "mdi:numeric-7-circle-outline",
+              "spped 8": "mdi:numeric-8-circle-outline",
+              "spped 9": "mdi:numeric-9-circle-outline",
+              "speed 10": "mdi:numeric-10-circle-outline",
+              "allergen": "pap:allergen_mode",
+              "auto": "pap:auto_mode",
+              "auto general": "pap:auto_mode",
+              "auto+": "pap:auto_mode",
+              "bacteria": "pap:bacteria_virus_mode",
+              "gentle": "mdi:butterfly-outline",
+              "night": "pap:sleep_mode",
+              "sleep": "pap:sleep_mode",
+              "allergy sleep": "pap:allergen_mode",
+              "turbo": "mdi:alpha-t-circle-outline",
+              "gas": "pap:gas",
+              "pollution": "mdi:liquid-spot",
+              "low": "pap:speed_1",
+              "high": "pap:speed_3",
+              "ventilation": "pap:fan_speed_button"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/custom_components/philips_airpurifier_coap/philips.py
+++ b/custom_components/philips_airpurifier_coap/philips.py
@@ -265,6 +265,12 @@ class PhilipsGenericFan(PhilipsEntity, FanEntity):
         self._model = model
         self._name = name
         self._unique_id = None
+        self._translation_key = "philips_generic_fan"
+
+    @property
+    def translation_key(self) -> Optional[str]:
+        """Return the translation ID of the fan."""
+        return self._translation_key
 
     @property
     def unique_id(self) -> Optional[str]:


### PR DESCRIPTION
Hi!

This PR maps icons to the fan entity's preset_modes so they are automatically used in dashboard cards, for example the Tile card. It uses the `pap:` icons that come with this integration whenever possible.

I don't own any of these air purifiers myself, so I only had a brief chance to test things. The icons do work (after clearing browser cache), but there were a couple deprecation warnings in hass's log, which this code may have introduced by accident. Feel free to edit or refuse this PR if things are not up to par.

Example card:
![ac_tile](https://github.com/kongo09/philips-airpurifier-coap/assets/28806220/2336fed0-8427-473b-82e3-68459b09a7c9)