### PR TITLE
feat: support cx355001 fan

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Philips has recently introduced a proper API to remote control the devices. Howe
 
 ## Configuration
 
-* The integration attempts to autodiscover your purifiers. Autodiscovery is based on the MAC address and original hostname of the devices. Home Assistant will notify you, if that is successful. 
+* The integration attempts to autodiscover your purifiers. Autodiscovery is based on the MAC address and original hostname of the devices. Home Assistant will notify you, if that is successful.
 * Alternatively, go to Configuration -> Devices & Services
 * Click `Add Integration`
 * Search for `Philips AirPurifier` and select it
@@ -89,6 +89,7 @@ Note: `configuration.yaml` is no longer supported and your configuration is not 
 - AMF765
 - AMF870
 - CX5120
+- CX3550/01
 
 
 ## Is your model not supported yet?

--- a/custom_components/philips_airpurifier_coap/const.py
+++ b/custom_components/philips_airpurifier_coap/const.py
@@ -127,6 +127,7 @@ class FanModel(StrEnum):
     AMF765 = "AMF765"
     AMF870 = "AMF870"
     CX5120 = "CX5120"
+    CX3550 = "CX3550/01"
 
 
 class PresetMode:
@@ -158,6 +159,7 @@ class PresetMode:
     LOW = "low"
     HIGH = "high"
     VENTILATION = "ventilation"
+    NATURAL = "natural"
 
     ICON_MAP = {
         ALLERGEN: ICON.ALLERGEN_MODE,
@@ -341,6 +343,11 @@ class PhilipsApi:
         SWITCH_ON: "17920",
         SWITCH_OFF: "0",
     }
+    OSCILLATION_MAP2 = {
+        SWITCH_ON: 17242,
+        SWITCH_OFF: 0,
+    }
+    OSCILLATION_CX355001 = 23040
 
     # the AC1715 seems to follow a new scheme, this should later be refactored
     NEW_NAME = "D01-03"

--- a/custom_components/philips_airpurifier_coap/philips.py
+++ b/custom_components/philips_airpurifier_coap/philips.py
@@ -1785,6 +1785,91 @@ class PhilipsCX5120(PhilipsNew2GenericCoAPFan):
     AVAILABLE_NUMBERS = [PhilipsApi.NEW2_TARGET_TEMP]
 
 
+class PhilipsCX3550(PhilipsNew2GenericCoAPFan):
+    """CX3550."""
+
+    AVAILABLE_PRESET_MODES = {
+        PresetMode.SPEED_1: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 1,
+            PhilipsApi.NEW2_MODE_C: 1,
+        },
+        PresetMode.SPEED_2: {
+            PhilipsApi.POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 2,
+            PhilipsApi.NEW2_MODE_C: 2,
+        },
+        PresetMode.SPEED_3: {
+            PhilipsApi.POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 3,
+            PhilipsApi.NEW2_MODE_C: 3,
+        },
+        PresetMode.NATURAL: {
+            PhilipsApi.POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: -126,
+            PhilipsApi.NEW2_MODE_C: 1,
+        },
+        PresetMode.SLEEP: {
+            PhilipsApi.POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 17,
+            PhilipsApi.NEW2_MODE_C: 2,
+        },
+    }
+    AVAILABLE_SPEEDS = {
+        PresetMode.SPEED_1: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 1,
+            PhilipsApi.NEW2_MODE_C: 1,
+        },
+        PresetMode.SPEED_2: {
+            PhilipsApi.POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 2,
+            PhilipsApi.NEW2_MODE_C: 2,
+        },
+        PresetMode.SPEED_3: {
+            PhilipsApi.POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 3,
+            PhilipsApi.NEW2_MODE_C: 3,
+        },
+    }
+    KEY_OSCILLATION = {
+        PhilipsApi.NEW2_OSCILLATION: PhilipsApi.OSCILLATION_MAP2,
+    }
+
+    AVAILABLE_SWITCHES = [PhilipsApi.NEW2_BEEP]
+    AVAILABLE_SELECTS = [PhilipsApi.NEW2_TIMER2]
+
+    @property
+    def oscillating(self) -> bool | None:
+        """Return if the fan is oscillating."""
+
+        key = next(iter(self.KEY_OSCILLATION))
+        status = self._device_status.get(key)
+        on = self.KEY_OSCILLATION.get(key).get(SWITCH_ON)
+        return status is not None and status in [on, PhilipsApi.OSCILLATION_CX355001]
+
+    async def async_oscillate(self, oscillating: bool) -> None:
+        """Osciallate the fan."""
+
+        await super().async_oscillate(oscillating)
+
+        self._device_status[PhilipsApi.NEW2_OSCILLATION] = (
+            PhilipsApi.OSCILLATION_MAP2.get(SWITCH_ON)
+            if oscillating
+            else PhilipsApi.OSCILLATION_MAP2.get(SWITCH_OFF)
+        )
+
+        self.async_write_ha_state()
+
+
 model_to_class = {
     FanModel.AC0850: PhilipsAC0850,
     FanModel.AC1214: PhilipsAC1214,
@@ -1816,4 +1901,5 @@ model_to_class = {
     FanModel.AMF765: PhilipsAMF765,
     FanModel.AMF870: PhilipsAMF870,
     FanModel.CX5120: PhilipsCX5120,
+    FanModel.CX3550: PhilipsCX3550,
 }


### PR DESCRIPTION
This PR adds support for the new CX3550/01 fan.
All features are working, including power cycling, speed mode selection, oscillation and timer.

Closes #137 

Credit also goes to @martlxmartl, @werty1st and @wehrmannit.