### PR TITLE
Adding AC0850/31 and icon translations for preset modes

### DIFF
--- a/custom_components/philips_airpurifier_coap/const.py
+++ b/custom_components/philips_airpurifier_coap/const.py
@@ -98,6 +98,7 @@ class FanModel(StrEnum):
     """Supported fan models."""
 
     AC0850 = "AC0850"
+    AC0850_31 = "AC0850/31"
     AC1214 = "AC1214"
     AC1715 = "AC1715"
     AC2729 = "AC2729"

--- a/custom_components/philips_airpurifier_coap/icons.json
+++ b/custom_components/philips_airpurifier_coap/icons.json
@@ -1,0 +1,30 @@
+{
+  "entity": {
+    "fan": {
+      "fan_translation": {
+        "state_attributes": {
+          "preset_mode": {
+            "default": "mdi:circle-small",
+            "state": {
+              "allergen": "pap:allergen_mode",
+              "auto": "pap:auto_mode",
+              "auto general": "pap:auto_mode",
+              "bacteria": "pap:bacteria_virus_mode",
+              "gentle/speed 1": "pap:speed_1",
+              "speed 1": "pap:speed_1",
+              "speed 2": "pap:speed_2",
+              "speed 3": "pap:speed_3",
+              "turbo": "pap:speed_3",
+              "gentle": "pap:sleep_mode",
+              "night": "pap:sleep_mode",
+              "sleep": "pap:sleep_mode",
+              "allergy sleep": "pap:auto_mode",
+              "pollution": "pap:auto_mode",
+              "gas": "pap:auto_mode"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/custom_components/philips_airpurifier_coap/manifest.json
+++ b/custom_components/philips_airpurifier_coap/manifest.json
@@ -1,7 +1,7 @@
 {
-  "domain": "philips_airpurifier_coap",
-  "name": "Philips AirPurifier (with CoAP)",
-  "codeowners": ["@kongo09"],
+  "domain": "philips_airpurifier",
+  "name": "Philips AirPurifier",
+  "codeowners": ["@hen_hick"],
   "config_flow": true,
   "dependencies": ["frontend", "http"],
   "dhcp": [
@@ -21,10 +21,10 @@
       "registered_devices": true
     }
   ],
-  "documentation": "https://github.com/kongo09/philips-airpurifier-coap",
+  "documentation": "https://github.com/hen-hick/philips-airpurifier-coap/",
   "integration_type": "device",
   "iot_class": "local_push",
-  "issue_tracker": "https://github.com/kongo09/philips-airpurifier-coap/issues",
+  "issue_tracker": "https://github.com/hen-hick/philips-airpurifier-coap/issues",
   "requirements": ["aioairctrl==0.2.5", "getmac==0.9.4"],
   "version": "0.18.9"
 }

--- a/custom_components/philips_airpurifier_coap/manifest.json
+++ b/custom_components/philips_airpurifier_coap/manifest.json
@@ -1,7 +1,7 @@
 {
-  "domain": "philips_airpurifier",
-  "name": "Philips AirPurifier",
-  "codeowners": ["@hen_hick"],
+  "domain": "philips_airpurifier_coap",
+  "name": "Philips AirPurifier (with CoAP)",
+  "codeowners": ["@kongo09"],
   "config_flow": true,
   "dependencies": ["frontend", "http"],
   "dhcp": [
@@ -21,10 +21,10 @@
       "registered_devices": true
     }
   ],
-  "documentation": "https://github.com/hen-hick/philips-airpurifier-coap/",
+  "documentation": "https://github.com/kongo09/philips-airpurifier-coap",
   "integration_type": "device",
   "iot_class": "local_push",
-  "issue_tracker": "https://github.com/hen-hick/philips-airpurifier-coap/issues",
+  "issue_tracker": "https://github.com/kongo09/philips-airpurifier-coap/issues",
   "requirements": ["aioairctrl==0.2.5", "getmac==0.9.4"],
   "version": "0.18.9"
 }

--- a/custom_components/philips_airpurifier_coap/philips.py
+++ b/custom_components/philips_airpurifier_coap/philips.py
@@ -508,16 +508,11 @@ class PhilipsGenericCoAPFanBase(PhilipsGenericFan):
     @property
     def icon(self) -> str:
         """Return the icon of the fan."""
+        """Return the icon of the fan."""
+        if self.is_on:
+            return "mdi:air-purifier"
         if not self.is_on:
-            return ICON.POWER_BUTTON
-
-        preset_mode = self.preset_mode
-        if preset_mode is None:
-            return ICON.FAN_SPEED_BUTTON
-        if preset_mode in PresetMode.ICON_MAP:
-            return PresetMode.ICON_MAP[preset_mode]
-
-        return ICON.FAN_SPEED_BUTTON
+            return "mdi:air-purifier-off"
 
 
 class PhilipsGenericCoAPFan(PhilipsGenericCoAPFanBase):

--- a/custom_components/philips_airpurifier_coap/philips.py
+++ b/custom_components/philips_airpurifier_coap/philips.py
@@ -513,6 +513,11 @@ class PhilipsGenericCoAPFanBase(PhilipsGenericFan):
 
         return ICON.FAN_SPEED_BUTTON
 
+    @property
+    def translation_key(self):
+        """translation key of the entity"""
+        return "fan_translation"
+
 
 class PhilipsGenericCoAPFan(PhilipsGenericCoAPFanBase):
     """Class to manage a generic Philips CoAP fan."""
@@ -658,6 +663,44 @@ class PhilipsAC0850(PhilipsNewGenericCoAPFan):
     }
     # the prefilter data is present but doesn't change for this device, so let's take it out
     UNAVAILABLE_FILTERS = [PhilipsApi.FILTER_NANOPROTECT_PREFILTER]
+
+# The AC0850/31 is somewhat similar to the AC0850, but uses the 3rd-generation API
+class PhilipsAC085031(PhilipsNew2GenericCoAPFan):
+    """AC0850/31."""
+
+    AVAILABLE_PRESET_MODES = {
+        PresetMode.AUTO: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_B: 0,
+        },
+        PresetMode.SLEEP: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_B: 17,
+        },
+        PresetMode.TURBO: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_B: 18,
+        },
+    }
+    # This makes the two static modes available as speeds. There is actually
+    # a distinct 'fan speed' field with additional distinct values, but this
+    # does not appear to be user-settable. This 'fan speed' corresponds to
+    # the following PM2.5 values when the mode is Auto:
+    # - Speed  1 = PM2.5  1-12 (Good)
+    # - Speed  2 = PM2.5 13-35 (Fair)
+    # - Speed  3 = PM2.5 36-55 (Poor)
+    # - Speed 18 = PM2.5   >55 (Very Poor)
+    # Additionally, Speeds 1 and 18 correspond to Sleep and Turbo, respectively.
+    AVAILABLE_SPEEDS = {
+        PresetMode.SLEEP: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_B: 17,
+        },
+        PresetMode.TURBO: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_B: 18,
+        },
+    }
 
 
 # the AC1715 seems to be a new class of devices that follows some patterns of its own

--- a/custom_components/philips_airpurifier_coap/philips.py
+++ b/custom_components/philips_airpurifier_coap/philips.py
@@ -519,6 +519,7 @@ class PhilipsGenericCoAPFanBase(PhilipsGenericFan):
 
         return ICON.FAN_SPEED_BUTTON
 
+
 class PhilipsGenericCoAPFan(PhilipsGenericCoAPFanBase):
     """Class to manage a generic Philips CoAP fan."""
 

--- a/custom_components/philips_airpurifier_coap/philips.py
+++ b/custom_components/philips_airpurifier_coap/philips.py
@@ -265,7 +265,13 @@ class PhilipsGenericFan(PhilipsEntity, FanEntity):
         self._model = model
         self._name = name
         self._unique_id = None
-
+        self._translation_key = "fan_translation"
+    
+    @property
+    def translation_key(self):
+        """Return the translation ID of the fan."""
+        return self._translation_key
+    
     @property
     def unique_id(self) -> Optional[str]:
         """Return the unique ID of the fan."""
@@ -512,12 +518,6 @@ class PhilipsGenericCoAPFanBase(PhilipsGenericFan):
             return PresetMode.ICON_MAP[preset_mode]
 
         return ICON.FAN_SPEED_BUTTON
-
-    @property
-    def translation_key(self):
-        """translation key of the entity"""
-        return "fan_translation"
-
 
 class PhilipsGenericCoAPFan(PhilipsGenericCoAPFanBase):
     """Class to manage a generic Philips CoAP fan."""


### PR DESCRIPTION
Adds AC0850/31 as new device, this should not conflict with others unless this newer version is discovered to use old API (this is causing the issues on #139 .

I have also added icon translations to the preset modes meaning you can now see icons when using tiles to select modes, example below.

<img width="251" alt="image" src="https://github.com/user-attachments/assets/a989b3bc-b7e7-4c90-8fba-0f76e9715aa7">

I am thinking that I may update the changing of the device icon to a simple air purifier on or off to stop duplication of the mode icons.

<img width="145" alt="image" src="https://github.com/user-attachments/assets/26dc54a2-d019-454f-8521-ef971b53c343">
