### PR TITLE
add new model AC0850/81

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Note: Some of these models seem to have a newer firmware that does not allow loc
 - AC0850/20 AWS_Philips_AIR
 - AC0850/20 AWS_Philips_AIR_Combo
 - AC0850/31
+- AC0850/81 AWS_Philips_AIR_Combo
 - AC0950
 - AC0951
 - AC1214

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Note: Some of these models seem to have a newer firmware that does not allow loc
 - AC0850/20 AWS_Philips_AIR
 - AC0850/20 AWS_Philips_AIR_Combo
 - AC0850/31
-- AC0850/81 AWS_Philips_AIR_Combo
+- AC0850/81
 - AC0950
 - AC0951
 - AC1214

--- a/custom_components/philips_airpurifier_coap/const.py
+++ b/custom_components/philips_airpurifier_coap/const.py
@@ -110,7 +110,7 @@ class FanModel(StrEnum):
     AC0850_20 = "AC0850/20 AWS_Philips_AIR"
     AC0850_20C = "AC0850/20 AWS_Philips_AIR_Combo"
     AC0850_31 = "AC0850/31"
-    AC0850_81 = "AC0850/81 AWS_Philips_AIR_Combo"
+    AC0850_81 = "AC0850/81"
     AC0950 = "AC0950"
     AC0951 = "AC0951"
     AC1214 = "AC1214"

--- a/custom_components/philips_airpurifier_coap/const.py
+++ b/custom_components/philips_airpurifier_coap/const.py
@@ -110,6 +110,7 @@ class FanModel(StrEnum):
     AC0850_20 = "AC0850/20 AWS_Philips_AIR"
     AC0850_20C = "AC0850/20 AWS_Philips_AIR_Combo"
     AC0850_31 = "AC0850/31"
+    AC0850_81 = "AC0850/81 AWS_Philips_AIR_Combo"
     AC0950 = "AC0950"
     AC0951 = "AC0951"
     AC1214 = "AC1214"

--- a/custom_components/philips_airpurifier_coap/philips.py
+++ b/custom_components/philips_airpurifier_coap/philips.py
@@ -595,6 +595,10 @@ class PhilipsAC085031(PhilipsAC085011C):
     """AC0850/31."""
 
 
+class PhilipsAC085081(PhilipsAC085011C):
+    """AC0850/81."""
+
+
 class PhilipsAC0950(PhilipsNew2GenericCoAPFan):
     """AC0950."""
 
@@ -1914,6 +1918,7 @@ model_to_class = {
     FanModel.AC0850_20: PhilipsAC085020,
     FanModel.AC0850_20C: PhilipsAC085020C,
     FanModel.AC0850_31: PhilipsAC085031,
+    FanModel.AC0850_81: PhilipsAC085081,
     FanModel.AC0950: PhilipsAC0950,
     FanModel.AC0951: PhilipsAC0951,
     FanModel.AC1214: PhilipsAC1214,


### PR DESCRIPTION
Hi! Thank you for the awesome integration!

I’m using the AC0850/81 model, which is very similar to the PhilipsAC085011C. I created a subclass for it, tested it on my Home Assistant, and it works quite well overall. However, I noticed that during  initialization, it sometimes times out and requires a few retries to connect successfully.

Here’s some additional information for your reference:

```
❯ aioairctrl --host 192.168.68.50 status --json
{"D01102": 5, "D01S03": "Danny Air Purifier", "D01S04": "Pluto", "D01S05": "AC0850/81", "D01107": 0, "D01108": 3, "D01109": 1, "D0110A": 8, "D0110B": 1, "D0110C": 18, "D0110F": 3, "D01S12": "0.1.3", "D01213": 0, "ProductId": "9f31604ecc3e11ec973806d016384e4a", "DeviceId": "2fc3bce7056811ef9a031396ec7e2255", "Runtime": 90065840, "rssi": -37, "wifilog": false, "free_memory": 187536, "WifiVersion": "AWS_Philips_AIR_Combo@1.2", "StatusType": "status", "ConnectType": "Online", "D03102": 1, "D0310A": 2, "D0310C": 0, "D0310D": 1, "D03120": 1, "D03221": 1, "D0312A": 1, "D0312B": 1, "D0312C": 4, "D03134": 1, "D03240": 0, "D05408": 4800, "D0540E": 4627}
```
![Screenshot from 2024-11-13 22-21-11](https://github.com/user-attachments/assets/42f9acf7-3b1d-4ccf-9ca7-34e523c437ee)
