### PR TITLE
fix: re-enable child lock switch

### DIFF
--- a/custom_components/philips_airpurifier_coap/philips.py
+++ b/custom_components/philips_airpurifier_coap/philips.py
@@ -1508,6 +1508,8 @@ class PhilipsAC385451(PhilipsAC385x51):
 class PhilipsAC385851(PhilipsAC385x51):
     """AC3858/51."""
 
+    AVAILABLE_SWITCHES = [PhilipsApi.CHILD_LOCK]
+
 
 class PhilipsAC385883(PhilipsAC385x51):
     """AC3858/83."""


### PR DESCRIPTION
Hey, Thanks for the awesome integration.

The integration of my AC3858/50 was flawless. However, after some time, I noticed that the Child Lock is not supported.

I did plan to explore how the integration works, but it looks like this functionality is already there.

I did make the attached modification to my local checkout code, and the missing Child Lock sensor and action appeared after a home assistant restart.

I am not sure why that helps. This should be handled by inheritance between the classes.