### PR TITLE
don't force specific version requirements

### DIFF
--- a/custom_components/philips_airpurifier_coap/manifest.json
+++ b/custom_components/philips_airpurifier_coap/manifest.json
@@ -28,6 +28,6 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/kongo09/philips-airpurifier-coap/issues",
-  "requirements": ["aioairctrl==0.2.5", "getmac==0.9.4"],
+  "requirements": ["aioairctrl>=0.2.5", "getmac>=0.9.4"],
   "version": "0.25.0"
 }


### PR DESCRIPTION
with getmac 0.9.5 required by other modules, forcing to getmac=0.9.4 breaks functionality