### PR TITLE
Add preset mode alias mapping for backwards compatibility

### DIFF
--- a/custom_components/philips_airpurifier_coap/climate.py
+++ b/custom_components/philips_airpurifier_coap/climate.py
@@ -216,6 +216,9 @@ class PhilipsHeater(PhilipsGenericControlBase, ClimateEntity):
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the fan mode of the heater."""
+        # Resolve alias if exists
+        preset_mode = PresetMode.ALIASES.get(preset_mode, preset_mode)
+
         if preset_mode not in self._attr_preset_modes:
             return
 

--- a/custom_components/philips_airpurifier_coap/const.py
+++ b/custom_components/philips_airpurifier_coap/const.py
@@ -205,6 +205,11 @@ class PresetMode:
     VENTILATION = "ventilation"
     NATURAL = "natural"
 
+    # Aliases for backwards compatibility
+    ALIASES = {
+        "allergy_sleep": "sleep_allergy",
+    }
+
     ICON_MAP = {
         SPEED_1: "pap:speed_1",
         SPEED_GENTLE_1: "pap:speed_1",

--- a/custom_components/philips_airpurifier_coap/philips.py
+++ b/custom_components/philips_airpurifier_coap/philips.py
@@ -307,6 +307,9 @@ class PhilipsGenericFanBase(PhilipsGenericControlBase, FanEntity):
         """Set the preset mode of the fan."""
         # the fan uses the preset modes as collected from the classes
 
+        # Resolve alias if exists
+        preset_mode = PresetMode.ALIASES.get(preset_mode, preset_mode)
+
         status_pattern = self._available_preset_modes.get(preset_mode)
         if status_pattern:
             await self.coordinator.client.set_control_values(data=status_pattern)
@@ -717,6 +720,9 @@ class PhilipsAC1214(PhilipsGenericFan):
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of the fan."""
         _LOGGER.debug("AC1214 async_set_preset_mode is called with: %s", preset_mode)
+
+        # Resolve alias if exists
+        preset_mode = PresetMode.ALIASES.get(preset_mode, preset_mode)
 
         # the AC1214 doesn't like it if we set a preset mode to switch on the device,
         # so it needs to be done in sequence


### PR DESCRIPTION
The update from v0.34.3 to v0.35.0 introduced a regression to the handling of the allergy sleep mode.

Previously the string `allergy_sleep` needed to be passed to the integration to set the device to the according mode. In v0.35.0 that has changed to `sleep_allergy`, which in terms of wording makes more sense, but breaks existing installations that previously used `allergy_sleep`.

This affects the following devices:
- PhilipsAC3021
- PhilipsAC385x51
- PhilipsAC4236

This PR proposes a mapping for the input mode, so both strings still work. 

A different proposed solution would be to mention that breaking change in the release notes.

I'm using the AC3021/10. 
And thank you for your work, much appreciated! :)
