### PR TITLE
Fix duplicate select entities via UNAVAILABLE_SELECTS

### DIFF
--- a/custom_components/philips_airpurifier_coap/manifest.json
+++ b/custom_components/philips_airpurifier_coap/manifest.json
@@ -1,9 +1,14 @@
 {
   "domain": "philips_airpurifier_coap",
   "name": "Philips AirPurifier (with CoAP)",
-  "codeowners": ["@kongo09"],
+  "codeowners": [
+    "@kongo09"
+  ],
   "config_flow": true,
-  "dependencies": ["frontend", "http"],
+  "dependencies": [
+    "frontend",
+    "http"
+  ],
   "dhcp": [
     {
       "macaddress": "6879C4*"
@@ -31,6 +36,9 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/kongo09/philips-airpurifier-coap/issues",
-  "requirements": ["aioairctrl==0.3.1", "getmac>=0.9.4"],
-  "version": "0.25.0"
+  "requirements": [
+    "aioairctrl==0.3.1",
+    "getmac>=0.9.4"
+  ],
+  "version": "v0.36.2"
 }

--- a/custom_components/philips_airpurifier_coap/philips.py
+++ b/custom_components/philips_airpurifier_coap/philips.py
@@ -1613,6 +1613,7 @@ class PhilipsAC4220(PhilipsAC22xx):
     """AC4220."""
 
     AVAILABLE_SELECTS: ClassVar = [PhilipsApi.NEW2_GAS_PREFERRED_INDEX]
+    UNAVAILABLE_SELECTS: ClassVar = [PhilipsApi.NEW2_PREFERRED_INDEX]
 
 
 class PhilipsAC4221(PhilipsAC4220):

--- a/custom_components/philips_airpurifier_coap/select.py
+++ b/custom_components/philips_airpurifier_coap/select.py
@@ -33,15 +33,18 @@ async def async_setup_entry(
     model_class = model_to_class.get(model)
     if model_class:
         available_selects = []
+        unavailable_selects = []
 
         for cls in reversed(model_class.__mro__):
             cls_available_selects = getattr(cls, "AVAILABLE_SELECTS", [])
             available_selects.extend(cls_available_selects)
+            cls_unavailable_selects = getattr(cls, "UNAVAILABLE_SELECTS", [])
+            unavailable_selects.extend(cls_unavailable_selects)
 
         selects = [
             PhilipsSelect(hass, entry, config_entry_data, select)
             for select in SELECT_TYPES
-            if select in available_selects
+            if select in available_selects and select not in unavailable_selects
         ]
 
         async_add_entities(selects, update_before_add=False)


### PR DESCRIPTION
## Problem

Devices like AC4220/AC4221 inherit `AVAILABLE_SELECTS = [TIMER2, LAMP_MODE, PREFERRED_INDEX]` from `PhilipsAC22xx` and define their own `AVAILABLE_SELECTS = [GAS_PREFERRED_INDEX]`. The MRO traversal in `select.py` accumulates both lists, creating **two** Preferred Index select entities:

- `PREFERRED_INDEX` — 2-option (IAI / PM2.5) — **spurious**
- `GAS_PREFERRED_INDEX` — 3-option (IAI / PM2.5 / Gas) — **correct**

Both control the same device setting. The 2-option variant shouldn't exist on gas-capable models.

## Fix

Add `UNAVAILABLE_SELECTS` support to `select.py`, mirroring the existing `UNAVAILABLE_SENSORS` / `UNAVAILABLE_FILTERS` pattern in `sensor.py` (lines 55–68):

1. **`select.py`**: Collect `UNAVAILABLE_SELECTS` via MRO traversal and exclude them from entity creation.
2. **`philips.py`**: Add `UNAVAILABLE_SELECTS = [PhilipsApi.NEW2_PREFERRED_INDEX]` to `PhilipsAC4220`.

## Result

AC4220/AC4221 gets: Timer, Lamp Mode, Gas Preferred Index (3-option).
The spurious 2-option Preferred Index entity is no longer created.

## Testing

Tested on AC4221/11 (NEW2-generation, CoAP). Confirmed only `select.air_purifier_gas_preferred_index` is created after the fix.