### PR TITLE
Add support for Philips AC4231

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Note: Some of these models seem to have a newer firmware that does not allow loc
 - AC3858/86
 - AC4220
 - AC4221
+- AC4231
 - AC4236
 - AC4550
 - AC4558

--- a/custom_components/philips_airpurifier_coap/const.py
+++ b/custom_components/philips_airpurifier_coap/const.py
@@ -158,6 +158,7 @@ class FanModel(StrEnum):
     AC3858_86 = "AC3858/86"
     AC4220 = "AC4220"
     AC4221 = "AC4221"
+    AC4231 = "AC4231"
     AC4236 = "AC4236"
     AC4550 = "AC4550"
     AC4558 = "AC4558"

--- a/custom_components/philips_airpurifier_coap/philips.py
+++ b/custom_components/philips_airpurifier_coap/philips.py
@@ -1677,6 +1677,10 @@ class PhilipsAC4236(PhilipsGenericFan):
     AVAILABLE_SELECTS: ClassVar = [PhilipsApi.PREFERRED_INDEX]
 
 
+class PhilipsAC4231(PhilipsAC4236):
+    """AC4231."""
+
+
 class PhilipsAC4558(PhilipsGenericFan):
     """AC4558."""
 
@@ -2223,6 +2227,7 @@ model_to_class = {
     FanModel.AC3858_86: PhilipsAC385886,
     FanModel.AC4220: PhilipsAC4220,
     FanModel.AC4221: PhilipsAC4221,
+    FanModel.AC4231: PhilipsAC4231,
     FanModel.AC4236: PhilipsAC4236,
     FanModel.AC4550: PhilipsAC4550,
     FanModel.AC4558: PhilipsAC4558,


### PR DESCRIPTION
## Summary

Adds Philips AC4231 as a supported fan model by mapping it to a small `PhilipsAC4231` subclass of the existing `PhilipsAC4236` implementation.

The model reports the same relevant local CoAP status/control fields observed for the AC4236-style implementation, including `pwr`, `mode`, `om`, `pm25`, `iaql`, `tvoc`, child lock, UI light and filter status fields.

Fixes #357.

## Validation

- `python3 -m compileall -q custom_components tests`
- Direct local status query against an AC4231/10 returned valid encrypted-CoAP status data.