### PR TITLE
Add timeout and reconnect-on-failure to control commands

### DIFF
--- a/custom_components/philips_airpurifier_coap/climate.py
+++ b/custom_components/philips_airpurifier_coap/climate.py
@@ -229,7 +229,7 @@ class PhilipsHeater(PhilipsGenericControlBase, ClimateEntity):
         if status_pattern is None:
             return
 
-        await self.coordinator.client.set_control_values(data=status_pattern)
+        await self.coordinator.set_control_values(data=status_pattern)
         self._device_status.update(status_pattern)
         self._handle_coordinator_update()
 
@@ -252,7 +252,7 @@ class PhilipsHeater(PhilipsGenericControlBase, ClimateEntity):
 
         value = self._oscillation_modes[SWITCH_ON] if swing_mode == SWING_ON else self._oscillation_modes[SWITCH_OFF]
 
-        await self.coordinator.client.set_control_value(self._oscillation_key, value)
+        await self.coordinator.set_control_value(self._oscillation_key, value)
         self._device_status[self._oscillation_key] = value
         self._handle_coordinator_update()
 
@@ -263,7 +263,7 @@ class PhilipsHeater(PhilipsGenericControlBase, ClimateEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the device."""
-        await self.coordinator.client.set_control_values(
+        await self.coordinator.set_control_values(
             data={
                 self._power_key: self._description[FanAttributes.ON],
             }
@@ -273,7 +273,7 @@ class PhilipsHeater(PhilipsGenericControlBase, ClimateEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the device."""
-        await self.coordinator.client.set_control_values(
+        await self.coordinator.set_control_values(
             data={
                 self._power_key: self._description[FanAttributes.OFF],
             }
@@ -290,6 +290,6 @@ class PhilipsHeater(PhilipsGenericControlBase, ClimateEntity):
         temperature = int(raw_temperature)
 
         target = max(self._attr_min_temp, min(temperature, self._attr_max_temp))
-        await self.coordinator.client.set_control_value(self._temperature_target_key, target)
+        await self.coordinator.set_control_value(self._temperature_target_key, target)
         self._device_status[self._temperature_target_key] = temperature
         self._handle_coordinator_update()

--- a/custom_components/philips_airpurifier_coap/coordinator.py
+++ b/custom_components/philips_airpurifier_coap/coordinator.py
@@ -90,6 +90,44 @@ class Coordinator:
         except Exception:
             _LOGGER.exception("_reconnect error")
 
+    async def set_control_value(self, *args, **kwargs) -> None:
+        """Send a single control value, with timeout and reconnect-on-failure."""
+        await self._send_command("set_control_value", *args, **kwargs)
+
+    async def set_control_values(self, *args, **kwargs) -> None:
+        """Send multiple control values, with timeout and reconnect-on-failure."""
+        await self._send_command("set_control_values", *args, **kwargs)
+
+    async def _send_command(self, method: str, *args, **kwargs) -> None:
+        """Send a command to the device, bounded by a timeout.
+
+        Unlike the observe stream, command requests are not watched by the
+        disconnect timer. A stale CoAP session therefore makes a command hang
+        indefinitely (observed for ~2h) and eventually surface as
+        aiocoap LibraryShutdown when the client is torn down for an unrelated
+        reason. Bound the call, and on any failure recreate the session and
+        retry the command exactly once on the fresh client.
+        """
+        try:
+            await asyncio.wait_for(
+                getattr(self.client, method)(*args, **kwargs),
+                timeout=self._timeout,
+            )
+            return
+        except Exception as ex:  # noqa: BLE001 - incl. TimeoutError and LibraryShutdown
+            _LOGGER.warning(
+                "Command '%s' to %s failed (%s); reconnecting and retrying once",
+                method,
+                self.host,
+                ex,
+            )
+
+        await self._reconnect()
+        await asyncio.wait_for(
+            getattr(self.client, method)(*args, **kwargs),
+            timeout=self._timeout,
+        )
+
     async def async_first_refresh(self) -> None:
         """Refresh the data for the first time."""
 

--- a/custom_components/philips_airpurifier_coap/humidifier.py
+++ b/custom_components/philips_airpurifier_coap/humidifier.py
@@ -168,7 +168,7 @@ class PhilipsHumidifier(PhilipsGenericControlBase, HumidifierEntity):
             else:
                 function_value = self._description[FanAttributes.HUMIDIFYING]
 
-            await self.coordinator.client.set_control_values(
+            await self.coordinator.set_control_values(
                 data={
                     self._power_key: self._description[FanAttributes.ON],
                     self._function_key: function_value,
@@ -181,7 +181,7 @@ class PhilipsHumidifier(PhilipsGenericControlBase, HumidifierEntity):
         # then we treat pure humidification devices
         elif self._function_key == self._power_key:
             status_pattern = self._available_preset_modes.get(mode)
-            await self.coordinator.client.set_control_values(data=status_pattern)
+            await self.coordinator.set_control_values(data=status_pattern)
             self._device_status.update(status_pattern)
             self._handle_coordinator_update()
 
@@ -192,7 +192,7 @@ class PhilipsHumidifier(PhilipsGenericControlBase, HumidifierEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the device."""
-        await self.coordinator.client.set_control_values(
+        await self.coordinator.set_control_values(
             data={
                 self._power_key: self._description[FanAttributes.ON],
             }
@@ -202,7 +202,7 @@ class PhilipsHumidifier(PhilipsGenericControlBase, HumidifierEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the device."""
-        await self.coordinator.client.set_control_values(
+        await self.coordinator.set_control_values(
             data={
                 self._power_key: self._description[FanAttributes.OFF],
             }
@@ -226,6 +226,6 @@ class PhilipsHumidifier(PhilipsGenericControlBase, HumidifierEntity):
         # now let's make sure we're on the steps and inside the boundaries
         target = round(humidity / step) * step
         target = max(self._attr_min_humidity, min(target, self._attr_max_humidity))
-        await self.coordinator.client.set_control_value(self._humidity_target_key, target)
+        await self.coordinator.set_control_value(self._humidity_target_key, target)
         self._device_status[self._humidity_target_key] = humidity
         self._handle_coordinator_update()

--- a/custom_components/philips_airpurifier_coap/light.py
+++ b/custom_components/philips_airpurifier_coap/light.py
@@ -178,13 +178,13 @@ class PhilipsLight(PhilipsEntity, LightEntity):
         else:
             value = self._on
 
-        await self.coordinator.client.set_control_value(self.kind, value)
+        await self.coordinator.set_control_value(self.kind, value)
         self._device_status[self.kind] = value
         self._handle_coordinator_update()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the light off."""
         self._attr_effect = EFFECT_OFF
-        await self.coordinator.client.set_control_value(self.kind, self._off)
+        await self.coordinator.set_control_value(self.kind, self._off)
         self._device_status[self.kind] = self._off
         self._handle_coordinator_update()

--- a/custom_components/philips_airpurifier_coap/number.py
+++ b/custom_components/philips_airpurifier_coap/number.py
@@ -109,6 +109,6 @@ class PhilipsNumber(PhilipsEntity, NumberEntity):
 
         _LOGGER.debug("setting number with: %s", value)
 
-        await self.coordinator.client.set_control_value(self.kind, int(value))
+        await self.coordinator.set_control_value(self.kind, int(value))
         self._device_status[self.kind] = int(value)
         self._handle_coordinator_update()

--- a/custom_components/philips_airpurifier_coap/philips.py
+++ b/custom_components/philips_airpurifier_coap/philips.py
@@ -257,14 +257,14 @@ class PhilipsGenericFanBase(PhilipsGenericControlBase, FanEntity):
             await self.async_set_percentage(percentage)
             return
 
-        await self.coordinator.client.set_control_value(self.KEY_PHILIPS_POWER, self.STATE_POWER_ON)
+        await self.coordinator.set_control_value(self.KEY_PHILIPS_POWER, self.STATE_POWER_ON)
 
         self._device_status[self.KEY_PHILIPS_POWER] = self.STATE_POWER_ON
         self._handle_coordinator_update()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the fan off."""
-        await self.coordinator.client.set_control_value(self.KEY_PHILIPS_POWER, self.STATE_POWER_OFF)
+        await self.coordinator.set_control_value(self.KEY_PHILIPS_POWER, self.STATE_POWER_OFF)
 
         self._device_status[self.KEY_PHILIPS_POWER] = self.STATE_POWER_OFF
         self._handle_coordinator_update()
@@ -299,7 +299,7 @@ class PhilipsGenericFanBase(PhilipsGenericControlBase, FanEntity):
 
         status_pattern = self._available_preset_modes.get(preset_mode)
         if status_pattern:
-            await self.coordinator.client.set_control_values(data=status_pattern)
+            await self.coordinator.set_control_values(data=status_pattern)
             self._device_status.update(status_pattern)
             self._handle_coordinator_update()
 
@@ -337,9 +337,9 @@ class PhilipsGenericFanBase(PhilipsGenericControlBase, FanEntity):
         off = values.get(SWITCH_OFF)
 
         if oscillating:
-            await self.coordinator.client.set_control_value(key, on)
+            await self.coordinator.set_control_value(key, on)
         else:
-            await self.coordinator.client.set_control_value(key, off)
+            await self.coordinator.set_control_value(key, off)
 
         self._device_status[key] = on if oscillating else off
         self._handle_coordinator_update()
@@ -369,7 +369,7 @@ class PhilipsGenericFanBase(PhilipsGenericControlBase, FanEntity):
             speed = percentage_to_ordered_list_item(self._speeds, percentage)
             status_pattern = self._available_speeds.get(speed)
             if status_pattern:
-                await self.coordinator.client.set_control_values(data=status_pattern)
+                await self.coordinator.set_control_values(data=status_pattern)
                 self._device_status.update(status_pattern)
                 self._handle_coordinator_update()
 
@@ -701,7 +701,7 @@ class PhilipsAC1214(PhilipsGenericFan):
         _LOGGER.debug("AC1214 switches to mode 'A' first")
         a_status_pattern = self._available_preset_modes.get(PresetMode.ALLERGEN)
         if a_status_pattern is not None:
-            await self.coordinator.client.set_control_values(data=a_status_pattern)
+            await self.coordinator.set_control_values(data=a_status_pattern)
         await asyncio.sleep(1)
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
@@ -712,7 +712,7 @@ class PhilipsAC1214(PhilipsGenericFan):
         # so it needs to be done in sequence
         if not self.is_on:
             _LOGGER.debug("AC1214 is switched on without setting a mode")
-            await self.coordinator.client.set_control_value(PhilipsApi.POWER, PhilipsApi.POWER_MAP[SWITCH_ON])
+            await self.coordinator.set_control_value(PhilipsApi.POWER, PhilipsApi.POWER_MAP[SWITCH_ON])
             await asyncio.sleep(1)
 
         # the AC1214 also doesn't seem to like switching to mode 'M' without cycling through mode 'A'
@@ -731,7 +731,7 @@ class PhilipsAC1214(PhilipsGenericFan):
                 await self.async_set_a()
             _LOGGER.debug("AC1214 sets preset mode to: %s", preset_mode)
             if status_pattern:
-                await self.coordinator.client.set_control_values(data=status_pattern)
+                await self.coordinator.set_control_values(data=status_pattern)
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the preset mode of the fan."""
@@ -741,7 +741,7 @@ class PhilipsAC1214(PhilipsGenericFan):
         # so it needs to be done in sequence
         if not self.is_on:
             _LOGGER.debug("AC1214 is switched on without setting a mode")
-            await self.coordinator.client.set_control_value(PhilipsApi.POWER, PhilipsApi.POWER_MAP[SWITCH_ON])
+            await self.coordinator.set_control_value(PhilipsApi.POWER, PhilipsApi.POWER_MAP[SWITCH_ON])
             await asyncio.sleep(1)
 
         current_pattern = self._available_preset_modes.get(self.preset_mode)
@@ -764,7 +764,7 @@ class PhilipsAC1214(PhilipsGenericFan):
                 await self.async_set_a()
             _LOGGER.debug("AC1214 sets speed percentage to: %s", percentage)
             if status_pattern:
-                await self.coordinator.client.set_control_values(data=status_pattern)
+                await self.coordinator.set_control_values(data=status_pattern)
 
     async def async_turn_on(
         self,
@@ -782,7 +782,7 @@ class PhilipsAC1214(PhilipsGenericFan):
         # so it needs to be done in sequence
         if not self.is_on:
             _LOGGER.debug("AC1214 is switched on without setting a mode")
-            await self.coordinator.client.set_control_value(PhilipsApi.POWER, PhilipsApi.POWER_MAP[SWITCH_ON])
+            await self.coordinator.set_control_value(PhilipsApi.POWER, PhilipsApi.POWER_MAP[SWITCH_ON])
             await asyncio.sleep(1)
 
         if preset_mode:

--- a/custom_components/philips_airpurifier_coap/select.py
+++ b/custom_components/philips_airpurifier_coap/select.py
@@ -107,7 +107,7 @@ class PhilipsSelect(PhilipsEntity, SelectEntity):
                 option,
                 option_key,
             )
-            await self.coordinator.client.set_control_value(self.kind, option_key)
+            await self.coordinator.set_control_value(self.kind, option_key)
             self._device_status[self.kind] = option_key
             self._handle_coordinator_update()
 

--- a/custom_components/philips_airpurifier_coap/switch.py
+++ b/custom_components/philips_airpurifier_coap/switch.py
@@ -90,12 +90,12 @@ class PhilipsSwitch(PhilipsEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs) -> None:
         """Switch the switch on."""
-        await self.coordinator.client.set_control_value(self.kind, self._on)
+        await self.coordinator.set_control_value(self.kind, self._on)
         self._device_status[self.kind] = self._on
         self._handle_coordinator_update()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Switch the switch off."""
-        await self.coordinator.client.set_control_value(self.kind, self._off)
+        await self.coordinator.set_control_value(self.kind, self._off)
         self._device_status[self.kind] = self._off
         self._handle_coordinator_update()


### PR DESCRIPTION
## Problem

`fan.set_preset_mode` (and other write commands) can hang indefinitely and then fail with `aiocoap.error.LibraryShutdown`. Captured on an AC0950/10: a command hung ~1h46m before dying when the integration was torn down at an HA restart.

Fixes #363

## Root cause

Commands are awaited directly on the CoAP client with no timeout and no error handling. The `Coordinator`'s disconnect watchdog (`_timer_disconnected`) is only reset by the observe stream, so it never detects a command-side stall: the request blocks until the client is shut down for an unrelated reason, surfacing as `LibraryShutdown`.

## Change

- New `Coordinator.set_control_value` / `set_control_values` wrappers backed by `_send_command`, which bounds the request with `asyncio.wait_for(timeout=self._timeout)` and, on any failure (incl. `TimeoutError` / `LibraryShutdown`), recreates the session via the existing `_reconnect()` and retries the command once.
- Routed all 28 command call sites (fan/light/switch/number/humidifier/climate/select) through the coordinator.

Reuses the existing `_reconnect()` and `self._timeout`; no new dependencies. A stalled command now fails fast, reopens the session, and retries once instead of hanging for hours.

## Notes

Happy to iterate and test further on real hardware, and to tune the timeout value if preferred (currently `self._timeout`, the device-reported value).