### PR TITLE
Fix setup timeout for devices that require a control trigger (e.g. CX3550)

### DIFF
--- a/custom_components/philips_airpurifier_coap/config_flow.py
+++ b/custom_components/philips_airpurifier_coap/config_flow.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from homeassistant.util.timeout import TimeoutManager
 
 from .const import CONF_DEVICE_ID, CONF_MODEL, CONF_STATUS, DOMAIN, PhilipsApi
-from .helpers import extract_model, extract_name
+from .helpers import extract_model, extract_name, get_status_with_trigger
 from .philips import model_to_class
 
 _LOGGER = logging.getLogger(__name__)
@@ -76,10 +76,11 @@ class PhilipsAirPurifierConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 client = await CoAPClient.create(self._host)
                 _LOGGER.debug("got a valid client for host %s", self._host)
 
-            # we give it 30s to get a status, otherwise we abort
-            async with timeout.async_timeout(30):
+            # Allow 60s: some devices (e.g. CX3550) need a control trigger
+            # before they push their first status, adding ~11s to the normal path.
+            async with timeout.async_timeout(60):
                 _LOGGER.debug("trying to get status")
-                status, _ = await client.get_status()
+                status, _ = await get_status_with_trigger(client)
                 _LOGGER.debug("got status")
 
             if client is not None:
@@ -215,10 +216,11 @@ class PhilipsAirPurifierConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         client = await CoAPClient.create(self._host)
                         _LOGGER.debug("got a valid client")
 
-                    # we give it 30s to get a status, otherwise we abort
-                    async with timeout.async_timeout(30):
+                    # Allow 60s: some devices (e.g. CX3550) need a control trigger
+                    # before they push their first status, adding ~11s to the normal path.
+                    async with timeout.async_timeout(60):
                         _LOGGER.debug("trying to get status")
-                        status, _ = await client.get_status()
+                        status, _ = await get_status_with_trigger(client)
                         _LOGGER.debug("got status")
 
                     if client is not None:
@@ -324,8 +326,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                         client = await CoAPClient.create(new_host)
                         _LOGGER.debug("options flow: got a valid client for host %s", new_host)
 
-                    async with timeout.async_timeout(30):
-                        status, _ = await client.get_status()
+                    async with timeout.async_timeout(60):
+                        status, _ = await get_status_with_trigger(client)
                         _LOGGER.debug("options flow: got status from host %s", new_host)
 
                     if client is not None:

--- a/custom_components/philips_airpurifier_coap/coordinator.py
+++ b/custom_components/philips_airpurifier_coap/coordinator.py
@@ -11,6 +11,7 @@ from aioairctrl import CoAPClient
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 
+from .const import PhilipsApi
 from .helpers import get_status_with_trigger
 from .timer import Timer
 

--- a/custom_components/philips_airpurifier_coap/coordinator.py
+++ b/custom_components/philips_airpurifier_coap/coordinator.py
@@ -83,9 +83,10 @@ class Coordinator:
             self.client = await CoAPClient.create(self.host)
             # Refresh status immediately after reconnect; uses trigger fallback
             # for devices (e.g. CX3550) that don't push the initial status.
+            # Timeout must exceed the full toggle sequence (~37 s minimum).
             try:
                 self.status, _ = await asyncio.wait_for(
-                    get_status_with_trigger(self.client), timeout=35
+                    get_status_with_trigger(self.client), timeout=60
                 )
                 for update_callback in self._listeners:
                     update_callback()

--- a/custom_components/philips_airpurifier_coap/coordinator.py
+++ b/custom_components/philips_airpurifier_coap/coordinator.py
@@ -11,6 +11,7 @@ from aioairctrl import CoAPClient
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 
+from .helpers import get_status_with_trigger
 from .timer import Timer
 
 _LOGGER = logging.getLogger(__name__)
@@ -80,6 +81,16 @@ class Coordinator:
             with contextlib.suppress(Exception):
                 await self.client.shutdown()
             self.client = await CoAPClient.create(self.host)
+            # Refresh status immediately after reconnect; uses trigger fallback
+            # for devices (e.g. CX3550) that don't push the initial status.
+            try:
+                self.status, _ = await asyncio.wait_for(
+                    get_status_with_trigger(self.client), timeout=35
+                )
+                for update_callback in self._listeners:
+                    update_callback()
+            except Exception:
+                _LOGGER.debug("Could not refresh status on reconnect for %s", self.host)
             self._start_observing()
 
         except asyncio.CancelledError:
@@ -94,7 +105,7 @@ class Coordinator:
         """Refresh the data for the first time."""
 
         try:
-            self.status, timeout = await self.client.get_status()
+            self.status, timeout = await get_status_with_trigger(self.client)
             self._timeout = timeout
             if self._timer_disconnected is not None:
                 self._timer_disconnected.setTimeout(timeout * MISSED_PACKAGE_COUNT)

--- a/custom_components/philips_airpurifier_coap/helpers.py
+++ b/custom_components/philips_airpurifier_coap/helpers.py
@@ -1,6 +1,53 @@
 """Helper functions for Philips air purifier status."""
 
+import asyncio
+import logging
+
 from .const import PhilipsApi
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def get_status_with_trigger(client) -> tuple[dict, int]:
+    """Get device status, with a control trigger fallback for push-only devices.
+
+    Some devices (e.g. CX3550) silently ignore the initial CoAP observe GET
+    and never send the first status push, causing setup to time out.  They do,
+    however, push a status update after receiving any encrypted control command.
+    We try the normal path first; on timeout we register the observe, fire a
+    beep-off command (D03130=0) to prompt the push, then collect the result.
+
+    See: https://github.com/kongo09/philips-airpurifier-coap/issues/205
+    """
+    try:
+        return await asyncio.wait_for(client.get_status(), timeout=10)
+    except (asyncio.TimeoutError, TimeoutError):
+        pass
+
+    _LOGGER.debug("get_status timed out, trying control-trigger approach")
+
+    status_holder: dict = {}
+
+    async def _collect() -> None:
+        async for status in client.observe_status():
+            status_holder["status"] = status
+            return
+
+    collect_task = asyncio.create_task(_collect())
+    # Yield so the observe GET is dispatched before the trigger is sent.
+    await asyncio.sleep(0.5)
+    try:
+        await asyncio.wait_for(client.set_control_values({"D03130": 0}), timeout=10)
+    except Exception:
+        collect_task.cancel()
+        raise
+
+    await asyncio.wait_for(collect_task, timeout=20)
+
+    if "status" not in status_holder:
+        raise TimeoutError("Device did not push status after control trigger")
+
+    return status_holder["status"], 60
 
 
 def extract_name(status: dict) -> str:

--- a/custom_components/philips_airpurifier_coap/helpers.py
+++ b/custom_components/philips_airpurifier_coap/helpers.py
@@ -11,11 +11,15 @@ _LOGGER = logging.getLogger(__name__)
 async def get_status_with_trigger(client) -> tuple[dict, int]:
     """Get device status, with a control trigger fallback for push-only devices.
 
-    Some devices (e.g. CX3550) silently ignore the initial CoAP observe GET
-    and never send the first status push, causing setup to time out.  They do,
-    however, push a status update after receiving any encrypted control command.
-    We try the normal path first; on timeout we register the observe, fire a
-    beep-off command (D03130=0) to prompt the push, then collect the result.
+    Some devices (e.g. CX3550) ignore the initial CoAP observe GET but push a
+    status update after receiving any encrypted control command.  We try the
+    normal path first; on timeout we register the observe, then toggle D03130
+    (beep) to guarantee a value change that the device will respond to, then
+    collect the first result.
+
+    We toggle D03130: first set 0, then 1 if no push arrives within 5 s.  This
+    ensures a change regardless of the current value.  We leave it at 0 (beep
+    off) and patch the captured status accordingly.
 
     See: https://github.com/kongo09/philips-airpurifier-coap/issues/205
     """
@@ -37,7 +41,17 @@ async def get_status_with_trigger(client) -> tuple[dict, int]:
     # Yield so the observe GET is dispatched before the trigger is sent.
     await asyncio.sleep(0.5)
     try:
+        # Try D03130=0 first (if D03130 was 1, this triggers a push immediately).
         await asyncio.wait_for(client.set_control_values({"D03130": 0}), timeout=10)
+        # Wait briefly; if the first trigger didn't fire (D03130 was already 0),
+        # send D03130=1 to guarantee a value change, then restore to 0.
+        try:
+            await asyncio.wait_for(asyncio.shield(collect_task), timeout=5)
+        except (asyncio.TimeoutError, TimeoutError):
+            _LOGGER.debug("D03130=0 did not trigger push (already 0?), toggling to 1")
+            await asyncio.wait_for(client.set_control_values({"D03130": 1}), timeout=10)
+            await asyncio.sleep(0.3)
+            await asyncio.wait_for(client.set_control_values({"D03130": 0}), timeout=10)
     except Exception:
         collect_task.cancel()
         raise
@@ -47,7 +61,12 @@ async def get_status_with_trigger(client) -> tuple[dict, int]:
     if "status" not in status_holder:
         raise TimeoutError("Device did not push status after control trigger")
 
-    return status_holder["status"], 60
+    # If the captured status has D03130=1 (from the toggle above), correct it to
+    # 0 since we immediately sent D03130=0 afterwards.
+    status = status_holder["status"]
+    if status.get("D03130") == 1:
+        status["D03130"] = 0
+    return status, 60
 
 
 def extract_name(status: dict) -> str:

--- a/custom_components/philips_airpurifier_coap/helpers.py
+++ b/custom_components/philips_airpurifier_coap/helpers.py
@@ -5,6 +5,8 @@ import logging
 
 from .const import PhilipsApi
 
+_BEEP_CONTROL_TRIGGER = PhilipsApi.NEW2_BEEP
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -13,11 +15,11 @@ async def get_status_with_trigger(client) -> tuple[dict, int]:
 
     Some devices (e.g. CX3550) ignore the initial CoAP observe GET but push a
     status update after receiving any encrypted control command.  We try the
-    normal path first; on timeout we register the observe, then toggle D03130
-    (beep) to guarantee a value change that the device will respond to, then
+    normal path first; on timeout we register the observe, then toggle the beep
+    control to guarantee a value change that the device will respond to, then
     collect the first result.
 
-    We toggle D03130: first set 0, then 1 if no push arrives within 5 s.  This
+    We toggle the beep: first set 0, then 1 if no push arrives within 5 s.  This
     ensures a change regardless of the current value.  We leave it at 0 (beep
     off) and patch the captured status accordingly.
 
@@ -41,17 +43,17 @@ async def get_status_with_trigger(client) -> tuple[dict, int]:
     # Yield so the observe GET is dispatched before the trigger is sent.
     await asyncio.sleep(0.5)
     try:
-        # Try D03130=0 first (if D03130 was 1, this triggers a push immediately).
-        await asyncio.wait_for(client.set_control_values({"D03130": 0}), timeout=10)
-        # Wait briefly; if the first trigger didn't fire (D03130 was already 0),
-        # send D03130=1 to guarantee a value change, then restore to 0.
+        # Try beep=0 first (if beep was 1, this triggers a push immediately).
+        await asyncio.wait_for(client.set_control_values({_BEEP_CONTROL_TRIGGER: 0}), timeout=10)
+        # Wait briefly; if the first trigger didn't fire (beep was already 0),
+        # send beep=1 to guarantee a value change, then restore to 0.
         try:
             await asyncio.wait_for(asyncio.shield(collect_task), timeout=5)
         except (asyncio.TimeoutError, TimeoutError):
-            _LOGGER.debug("D03130=0 did not trigger push (already 0?), toggling to 1")
-            await asyncio.wait_for(client.set_control_values({"D03130": 1}), timeout=10)
+            _LOGGER.debug("Beep=0 did not trigger push (already 0?), toggling to 1")
+            await asyncio.wait_for(client.set_control_values({_BEEP_CONTROL_TRIGGER: 1}), timeout=10)
             await asyncio.sleep(0.3)
-            await asyncio.wait_for(client.set_control_values({"D03130": 0}), timeout=10)
+            await asyncio.wait_for(client.set_control_values({_BEEP_CONTROL_TRIGGER: 0}), timeout=10)
     except Exception:
         collect_task.cancel()
         raise
@@ -61,11 +63,11 @@ async def get_status_with_trigger(client) -> tuple[dict, int]:
     if "status" not in status_holder:
         raise TimeoutError("Device did not push status after control trigger")
 
-    # If the captured status has D03130=1 (from the toggle above), correct it to
-    # 0 since we immediately sent D03130=0 afterwards.
+    # If the captured status has beep=1 (from the toggle above), correct it to
+    # 0 since we immediately sent beep=0 afterwards.
     status = status_holder["status"]
-    if status.get("D03130") == 1:
-        status["D03130"] = 0
+    if status.get(_BEEP_CONTROL_TRIGGER) == 1:
+        status[_BEEP_CONTROL_TRIGGER] = 0
     return status, 60
 
 

--- a/custom_components/philips_airpurifier_coap/philips.py
+++ b/custom_components/philips_airpurifier_coap/philips.py
@@ -2038,36 +2038,34 @@ class PhilipsCX5120(PhilipsNew2GenericFan):
 class PhilipsCX3550(PhilipsNew2GenericFan):
     """CX3550."""
 
+    # NEW2_MODE_C (D0310D) is omitted: the device does not reflect it back in
+    # status pushes, so including it prevents preset-mode detection from ever
+    # matching.  NEW2_MODE_B (D0310C) alone uniquely identifies each preset.
     AVAILABLE_PRESET_MODES: ClassVar = {
         PresetMode.SPEED_1: {
             PhilipsApi.NEW2_POWER: 1,
             PhilipsApi.NEW2_MODE_A: 1,
             PhilipsApi.NEW2_MODE_B: 1,
-            PhilipsApi.NEW2_MODE_C: 1,
         },
         PresetMode.SPEED_2: {
             PhilipsApi.NEW2_POWER: 1,
             PhilipsApi.NEW2_MODE_A: 1,
             PhilipsApi.NEW2_MODE_B: 2,
-            PhilipsApi.NEW2_MODE_C: 2,
         },
         PresetMode.SPEED_3: {
             PhilipsApi.NEW2_POWER: 1,
             PhilipsApi.NEW2_MODE_A: 1,
             PhilipsApi.NEW2_MODE_B: 3,
-            PhilipsApi.NEW2_MODE_C: 3,
         },
         PresetMode.NATURAL: {
             PhilipsApi.NEW2_POWER: 1,
             PhilipsApi.NEW2_MODE_A: 1,
             PhilipsApi.NEW2_MODE_B: -126,
-            PhilipsApi.NEW2_MODE_C: 1,
         },
         PresetMode.SLEEP: {
             PhilipsApi.NEW2_POWER: 1,
             PhilipsApi.NEW2_MODE_A: 1,
             PhilipsApi.NEW2_MODE_B: 17,
-            PhilipsApi.NEW2_MODE_C: 2,
         },
     }
     AVAILABLE_SPEEDS: ClassVar = {
@@ -2075,19 +2073,16 @@ class PhilipsCX3550(PhilipsNew2GenericFan):
             PhilipsApi.NEW2_POWER: 1,
             PhilipsApi.NEW2_MODE_A: 1,
             PhilipsApi.NEW2_MODE_B: 1,
-            PhilipsApi.NEW2_MODE_C: 1,
         },
         PresetMode.SPEED_2: {
             PhilipsApi.NEW2_POWER: 1,
             PhilipsApi.NEW2_MODE_A: 1,
             PhilipsApi.NEW2_MODE_B: 2,
-            PhilipsApi.NEW2_MODE_C: 2,
         },
         PresetMode.SPEED_3: {
             PhilipsApi.NEW2_POWER: 1,
             PhilipsApi.NEW2_MODE_A: 1,
             PhilipsApi.NEW2_MODE_B: 3,
-            PhilipsApi.NEW2_MODE_C: 3,
         },
     }
     KEY_OSCILLATION: ClassVar = {


### PR DESCRIPTION
## Problem

The CX3550/01 (firmware \`AWS_Philips_AIR_Combo@86\`, device FW \`0.1.7\`) silently ignores the initial CoAP \`GET /sys/dev/status observe=0\` and never sends the first status push. This causes both DHCP auto-discovery and manual setup to time out after 30 seconds, making the device impossible to add. Related: #205.

Confirmed via direct aiocoap testing against the device:
- \`POST /sys/dev/sync\` → responds correctly with client key ✅
- \`GET /sys/dev/status observe=0\` → no response, ever ❌
- After sending any encrypted \`POST /sys/dev/control\` → device immediately pushes full status via the observe subscription ✅

## Solution

Add \`get_status_with_trigger()\` in \`helpers.py\` that:
1. Tries the standard \`client.get_status()\` with a 10 s timeout (zero cost for normal devices)
2. On timeout, registers the CoAP observe and sends \`D03130=0\` (beep off) as a trigger
3. If no push arrives within 5 s (meaning \`D03130\` was already 0 and no value change occurred), toggles \`D03130=1\` then immediately restores it to \`0\` to guarantee a value change the device will respond to
4. Waits up to 20 s for the device to push its status back; patches the captured status to show \`D03130=0\` if the toggle left it at 1

Use this helper in place of \`client.get_status()\` in:
- \`config_flow.py\` — all three flow paths (DHCP discovery, manual user flow, options flow), with the status timeout raised from 30 s → 60 s
- \`coordinator.py\` — \`async_first_refresh()\` and \`_reconnect()\`, so state is refreshed immediately after HA restarts rather than waiting for the next device-side change; reconnect timeout raised 35 s → 60 s to accommodate the full toggle sequence (~37 s minimum)

Fix preset-mode detection for the CX3550 in \`philips.py\`: the device does not reflect \`NEW2_MODE_C\` (D0310D) back in status pushes, so including it in preset patterns prevented the current preset from ever being recognised. Since \`NEW2_MODE_B\` (D0310C) alone uniquely identifies each CX3550 preset, \`NEW2_MODE_C\` has been removed from \`AVAILABLE_PRESET_MODES\` and \`AVAILABLE_SPEEDS\`.

## Testing

Tested against a CX3550/01 at firmware \`AWS_Philips_AIR_Combo@86\`:
- Setup completes in ~12 s (10 s initial timeout + ~2 s for trigger round-trip)
- Reconnect correctly refreshes state on each 180 s cycle, including when \`D03130\` is already 0 (uses the 1→0 toggle path)
- Speed presets (Speed 1–3, Natural, Sleep) and timer select are correctly detected and controllable
- Normal devices (that respond to \`get_status()\` immediately) are unaffected — the trigger path is never reached