### PR TITLE
feat: add support for Philips Air Ventilator CX7550/01

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Note: Some of these models seem to have a newer firmware that does not allow loc
 - CX3120
 - CX5120
 - CX3550
+- CX7550
 - HU1509
 - HU1510
 - HU5710

--- a/custom_components/philips_airpurifier_coap/const.py
+++ b/custom_components/philips_airpurifier_coap/const.py
@@ -168,6 +168,7 @@ class FanModel(StrEnum):
     CX3120 = "CX3120"
     CX3550 = "CX3550"
     CX5120 = "CX5120"
+    CX7550 = "CX7550"
     HU1509 = "HU1509"
     HU1510 = "HU1510"
     HU5710 = "HU5710"
@@ -187,6 +188,8 @@ class PresetMode:
     SPEED_8 = "speed_8"
     SPEED_9 = "speed_9"
     SPEED_10 = "speed_10"
+    SPEED_11 = "speed_11"
+    SPEED_12 = "speed_12"
     ALLERGEN = "allergen"
     AUTO = "auto"
     AUTO_GENERAL = "auto_general"
@@ -205,6 +208,7 @@ class PresetMode:
     HIGH = "high"
     VENTILATION = "ventilation"
     NATURAL = "natural"
+    MANUAL = "manual"
 
     ICON_MAP: ClassVar = {
         SPEED_1: "pap:speed_1",
@@ -218,6 +222,8 @@ class PresetMode:
         SPEED_8: "pap:fan_speed_button",
         SPEED_9: "pap:fan_speed_button",
         SPEED_10: "pap:fan_speed_button",
+        SPEED_11: "pap:fan_speed_button",
+        SPEED_12: "pap:fan_speed_button",
         ALLERGEN: "pap:allergen_mode",
         AUTO: "pap:auto_mode_button",
         AUTO_GENERAL: "pap:auto_mode_button",
@@ -236,6 +242,7 @@ class PresetMode:
         HIGH: "pap:speed_3",
         VENTILATION: "pap:circulate",
         NATURAL: "pap:fan_speed_button",
+        MANUAL: "pap:fan_speed_button",
     }
 
 
@@ -344,6 +351,8 @@ class FanAttributes(StrEnum):
     WATER_TANK = "water_tank"
     AUTO_QUICKDRY_MODE = "auto_quickdry_mode"
     QUICKDRY_MODE = "quickdry_mode"
+    TEMPERATURE_COLOR = "temperature_color"
+    STANDBY_TEMPERATURE = "standby_temperature"
 
 
 class FanUnits(StrEnum):
@@ -434,6 +443,11 @@ class PhilipsApi:
         SWITCH_ON: 17222,
         SWITCH_OFF: 0,
     }
+    # CX7550 uses this map
+    OSCILLATION_MAP5: ClassVar = {
+        SWITCH_ON: 80,
+        SWITCH_OFF: 0,
+    }
 
     # the AC1715 seems to follow a new scheme, this should later be refactored
     NEW_NAME = "D01-03"
@@ -451,6 +465,7 @@ class PhilipsApi:
     NEW2_NAME = "D01S03"
     NEW2_MODEL_ID = "D01S05"
     NEW2_POWER = "D03102"
+    NEW2_TEMPERATURE_COLOR = "D03104"
     NEW2_DISPLAY_BACKLIGHT = "D0312D"
     NEW2_DISPLAY_BACKLIGHT2 = "D03105"
     NEW2_DISPLAY_BACKLIGHT3 = "D03105#1"  # dimmable in 3 steps with auto
@@ -490,6 +505,7 @@ class PhilipsApi:
     NEW2_TARGET_TEMP = "D0310E"
     NEW2_HEATING_ACTION = "D0313F"
     NEW2_STANDBY_SENSORS = "D03134"
+    NEW2_STANDBY_TEMPERATURE = "D03133"
     NEW2_AUTO_PLUS_AI = "D03180"
     NEW2_PREFERRED_INDEX = "D0312A#1"
     NEW2_GAS_PREFERRED_INDEX = "D0312A#2"
@@ -867,6 +883,24 @@ SWITCH_TYPES: dict[str, SwitchDescription] = {
     PhilipsApi.NEW2_QUICKDRY_MODE: {
         FanAttributes.LABEL: FanAttributes.QUICKDRY_MODE,
         SWITCH_ON: 1,
+        SWITCH_OFF: 0,
+    },
+    PhilipsApi.NEW2_TEMPERATURE_COLOR: {
+        FanAttributes.LABEL: FanAttributes.TEMPERATURE_COLOR,
+        CONF_ENTITY_CATEGORY: EntityCategory.CONFIG,
+        SWITCH_ON: 100,
+        SWITCH_OFF: 0,
+    },
+    PhilipsApi.NEW2_STANDBY_TEMPERATURE: {
+        FanAttributes.LABEL: FanAttributes.STANDBY_TEMPERATURE,
+        CONF_ENTITY_CATEGORY: EntityCategory.CONFIG,
+        SWITCH_ON: 1,
+        SWITCH_OFF: 0,
+    },
+    PhilipsApi.NEW2_OSCILLATION: {
+        FanAttributes.LABEL: FanAttributes.OSCILLATION,
+        CONF_ENTITY_CATEGORY: EntityCategory.CONFIG,
+        SWITCH_ON: 80,
         SWITCH_OFF: 0,
     },
 }

--- a/custom_components/philips_airpurifier_coap/philips.py
+++ b/custom_components/philips_airpurifier_coap/philips.py
@@ -2174,6 +2174,135 @@ class PhilipsHU5710(PhilipsNew2GenericFan):
     AVAILABLE_HUMIDIFIERS: ClassVar = [PhilipsApi.NEW2_HUMIDITY_TARGET2]
 
 
+class PhilipsCX7550(PhilipsNew2GenericFan):
+    """CX7550."""
+
+    AVAILABLE_PRESET_MODES: ClassVar = {
+        PresetMode.AUTO: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_B: 0,
+        },
+        PresetMode.NATURAL: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_B: -126,
+        },
+        PresetMode.SLEEP: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_B: 17,
+        },
+        PresetMode.MANUAL: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 1,
+            PhilipsApi.NEW2_MODE_C: 1,
+        },
+    }
+    AVAILABLE_SPEEDS: ClassVar = {
+        PresetMode.SPEED_1: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 1,
+            PhilipsApi.NEW2_MODE_C: 1,
+        },
+        PresetMode.SPEED_2: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 2,
+            PhilipsApi.NEW2_MODE_C: 2,
+        },
+        PresetMode.SPEED_3: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 3,
+            PhilipsApi.NEW2_MODE_C: 3,
+        },
+        PresetMode.SPEED_4: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 4,
+            PhilipsApi.NEW2_MODE_C: 4,
+        },
+        PresetMode.SPEED_5: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 5,
+            PhilipsApi.NEW2_MODE_C: 5,
+        },
+        PresetMode.SPEED_6: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 6,
+            PhilipsApi.NEW2_MODE_C: 6,
+        },
+        PresetMode.SPEED_7: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 7,
+            PhilipsApi.NEW2_MODE_C: 7,
+        },
+        PresetMode.SPEED_8: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 8,
+            PhilipsApi.NEW2_MODE_C: 8,
+        },
+        PresetMode.SPEED_9: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 9,
+            PhilipsApi.NEW2_MODE_C: 9,
+        },
+        PresetMode.SPEED_10: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 10,
+            PhilipsApi.NEW2_MODE_C: 10,
+        },
+        PresetMode.SPEED_11: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 81,
+            PhilipsApi.NEW2_MODE_C: 81,
+        },
+        PresetMode.SPEED_12: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 82,
+            PhilipsApi.NEW2_MODE_C: 82,
+        },
+    }
+    AVAILABLE_LIGHTS: ClassVar = [PhilipsApi.NEW2_DISPLAY_BACKLIGHT4]
+    AVAILABLE_SWITCHES: ClassVar = [
+        PhilipsApi.NEW2_BEEP,
+        PhilipsApi.NEW2_TEMPERATURE_COLOR,
+        PhilipsApi.NEW2_STANDBY_TEMPERATURE,
+        PhilipsApi.NEW2_OSCILLATION,
+    ]
+    AVAILABLE_SELECTS: ClassVar = [PhilipsApi.NEW2_TIMER2]
+
+    _MANUAL_MODE_B_VALUES: ClassVar = {0, -126, 17}
+
+    @property
+    def preset_mode(self) -> str | None:
+        """Return the selected preset mode."""
+        # First check the standard presets (Auto, Natural, Sleep, Manual speed 1)
+        for preset_mode, status_pattern in self._available_preset_modes.items():
+            for k, v in status_pattern.items():
+                status = self._device_status.get(k)
+                if status != v:
+                    break
+            else:
+                return preset_mode
+
+        # Check if in manual mode at any speed (mode_b not a special mode value)
+        if self._device_status.get(PhilipsApi.NEW2_POWER) == 1:
+            mode_b = self._device_status.get(PhilipsApi.NEW2_MODE_B)
+            if mode_b is not None and mode_b not in self._MANUAL_MODE_B_VALUES:
+                return PresetMode.MANUAL
+
+        return None
+
+
 model_to_class = {
     FanModel.AC0850_11: PhilipsAC085011,
     FanModel.AC0850_11C: PhilipsAC085011C,
@@ -2233,6 +2362,7 @@ model_to_class = {
     FanModel.CX3120: PhilipsCX3120,
     FanModel.CX5120: PhilipsCX5120,
     FanModel.CX3550: PhilipsCX3550,
+    FanModel.CX7550: PhilipsCX7550,
     FanModel.HU1509: PhilipsHU1510,
     FanModel.HU1510: PhilipsHU1510,
     FanModel.HU5710: PhilipsHU5710,

--- a/custom_components/philips_airpurifier_coap/strings.json
+++ b/custom_components/philips_airpurifier_coap/strings.json
@@ -63,6 +63,7 @@
               "high": "High",
               "ventilation": "Ventilation",
               "natural": "Natural",
+              "manual": "Manual",
               "speed_1": "Speed 1",
               "gentle_speed_1": "Gentle/Speed 1",
               "speed_2": "Speed 2",
@@ -73,7 +74,9 @@
               "speed_7": "Speed 7",
               "speed_8": "Speed 8",
               "speed_9": "Speed 9",
-              "speed_10": "Speed 10"
+              "speed_10": "Speed 10",
+              "speed_11": "Speed 11",
+              "speed_12": "Speed 12"
             }
           }
         }
@@ -226,6 +229,15 @@
       },
       "quickdry_mode": {
         "name": "Quickdry mode"
+      },
+      "temperature_color": {
+        "name": "Temperature color"
+      },
+      "standby_temperature": {
+        "name": "Standby temperature"
+      },
+      "oscillation": {
+        "name": "Oscillation"
       }
     },
     "light": {

--- a/custom_components/philips_airpurifier_coap/translations/de.json
+++ b/custom_components/philips_airpurifier_coap/translations/de.json
@@ -47,6 +47,7 @@
               "high": "Hoch",
               "ventilation": "Durchlüftung",
               "natural": "Natürlich",
+              "manual": "Manuell",
               "speed_1": "Geschwindigkeit 1",
               "gentle_speed_1": "Sanft/Geschwindigkeit 1",
               "speed_2": "Geschwindigkeit 2",
@@ -57,7 +58,9 @@
               "speed_7": "Geschwindigkeit 7",
               "speed_8": "Geschwindigkeit 8",
               "speed_9": "Geschwindigkeit 9",
-              "speed_10": "Geschwindigkeit 10"
+              "speed_10": "Geschwindigkeit 10",
+              "speed_11": "Geschwindigkeit 11",
+              "speed_12": "Geschwindigkeit 12"
             }
           }
         }
@@ -210,6 +213,15 @@
       },
       "quickdry_mode": {
         "name": "Manueller QuickDry-Modus"
+      },
+      "temperature_color": {
+        "name": "Temperatur Farbe aktiv"
+      },
+      "standby_temperature": {
+        "name": "Temperatur im Standby"
+      },
+      "oscillation": {
+        "name": "Oszillation"
       }
     },
     "light": {

--- a/custom_components/philips_airpurifier_coap/translations/en.json
+++ b/custom_components/philips_airpurifier_coap/translations/en.json
@@ -63,6 +63,7 @@
               "high": "High",
               "ventilation": "Ventilation",
               "natural": "Natural",
+              "manual": "Manual",
               "speed_1": "Speed 1",
               "gentle_speed_1": "Gentle/Speed 1",
               "speed_2": "Speed 2",
@@ -73,7 +74,9 @@
               "speed_7": "Speed 7",
               "speed_8": "Speed 8",
               "speed_9": "Speed 9",
-              "speed_10": "Speed 10"
+              "speed_10": "Speed 10",
+              "speed_11": "Speed 11",
+              "speed_12": "Speed 12"
             }
           }
         }
@@ -226,6 +229,15 @@
       },
       "quickdry_mode": {
         "name": "Quickdry mode"
+      },
+      "temperature_color": {
+        "name": "Temperature color on"
+      },
+      "standby_temperature": {
+        "name": "Temperature in standby"
+      },
+      "oscillation": {
+        "name": "Oscillation"
       }
     },
     "light": {


### PR DESCRIPTION
Add PhilipsCX7550 class with 12 speeds, Auto/Natural/Sleep/Manual presets, oscillation switch, temperature color and standby temperature switches, display backlight, timer, beep, and temperature sensor. Translations added for EN and DE.