### PR TITLE
Add support for CX7550 (Smart Tower Fan 7000 series)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Note: Some of these models seem to have a newer firmware that does not allow loc
 - CX3120
 - CX5120
 - CX3550
+- CX7550
 - HU1509
 - HU1510
 - HU4209

--- a/custom_components/philips_airpurifier_coap/const.py
+++ b/custom_components/philips_airpurifier_coap/const.py
@@ -278,7 +278,6 @@ class FanAttributes(StrEnum):
     BEEP = "beep"
     TEMP_COLOR = "temp_color"
     TEMP_IN_STANDBY = "temp_in_standby"
-    DISPLAY_BRIGHTNESS = "display_brightness"
     DISPLAY_INDICATOR = "display_indicator"
     DEVICE_ID = "device_id"
     DEVICE_VERSION = "device_version"
@@ -451,11 +450,6 @@ class PhilipsApi:
         SWITCH_ON: 80,
         SWITCH_OFF: 0,
     }
-    DISPLAY_BRIGHTNESS_MAP: ClassVar = {
-        0: "off",
-        115: "low",
-        123: "high",
-    }
     DISPLAY_INDICATOR_MAP: ClassVar = {
         7: "fan_speed",
         5: "temperature",
@@ -490,7 +484,6 @@ class PhilipsApi:
     NEW2_BEEP = "D03130"
     NEW2_DISPLAY_TEMP_COLOR = "D03104"
     NEW2_TEMP_STANDBY_DISPLAY = "D03133"
-    NEW2_DISPLAY_BRIGHTNESS = "D03105"
     NEW2_DISPLAY_INDICATOR = "D0312A"
     NEW2_INDOOR_ALLERGEN_INDEX = "D03120"
     NEW2_PM25 = "D03221"
@@ -1043,11 +1036,6 @@ SELECT_TYPES: dict[str, SelectDescription] = {
         FanAttributes.LABEL: FanAttributes.TIMER,
         CONF_ENTITY_CATEGORY: EntityCategory.CONFIG,
         OPTIONS: PhilipsApi.TIMER2_MAP,
-    },
-    PhilipsApi.NEW2_DISPLAY_BRIGHTNESS: {
-        FanAttributes.LABEL: FanAttributes.DISPLAY_BRIGHTNESS,
-        CONF_ENTITY_CATEGORY: EntityCategory.CONFIG,
-        OPTIONS: PhilipsApi.DISPLAY_BRIGHTNESS_MAP,
     },
     PhilipsApi.NEW2_DISPLAY_INDICATOR: {
         FanAttributes.LABEL: FanAttributes.DISPLAY_INDICATOR,

--- a/custom_components/philips_airpurifier_coap/const.py
+++ b/custom_components/philips_airpurifier_coap/const.py
@@ -276,6 +276,10 @@ class FanAttributes(StrEnum):
     AIR_QUALITY = "air_quality"
     CHILD_LOCK = "child_lock"
     BEEP = "beep"
+    TEMP_COLOR = "temp_color"
+    TEMP_IN_STANDBY = "temp_in_standby"
+    DISPLAY_BRIGHTNESS = "display_brightness"
+    DISPLAY_INDICATOR = "display_indicator"
     DEVICE_ID = "device_id"
     DEVICE_VERSION = "device_version"
     DISPLAY_BACKLIGHT = "display_backlight"
@@ -447,6 +451,15 @@ class PhilipsApi:
         SWITCH_ON: 80,
         SWITCH_OFF: 0,
     }
+    DISPLAY_BRIGHTNESS_MAP: ClassVar = {
+        0: "off",
+        115: "low",
+        123: "high",
+    }
+    DISPLAY_INDICATOR_MAP: ClassVar = {
+        7: "fan_speed",
+        5: "temperature",
+    }
 
     # the AC1715 seems to follow a new scheme, this should later be refactored
     NEW_NAME = "D01-03"
@@ -475,6 +488,10 @@ class PhilipsApi:
     NEW2_SOFTWARE_VERSION = "D01S12"
     NEW2_CHILD_LOCK = "D03103"
     NEW2_BEEP = "D03130"
+    NEW2_DISPLAY_TEMP_COLOR = "D03104"
+    NEW2_TEMP_STANDBY_DISPLAY = "D03133"
+    NEW2_DISPLAY_BRIGHTNESS = "D03105"
+    NEW2_DISPLAY_INDICATOR = "D0312A"
     NEW2_INDOOR_ALLERGEN_INDEX = "D03120"
     NEW2_PM25 = "D03221"
     NEW2_GAS = "D03122"
@@ -864,6 +881,18 @@ SWITCH_TYPES: dict[str, SwitchDescription] = {
         SWITCH_ON: 100,
         SWITCH_OFF: 0,
     },
+    PhilipsApi.NEW2_DISPLAY_TEMP_COLOR: {
+        FanAttributes.LABEL: FanAttributes.TEMP_COLOR,
+        CONF_ENTITY_CATEGORY: EntityCategory.CONFIG,
+        SWITCH_ON: 100,
+        SWITCH_OFF: 0,
+    },
+    PhilipsApi.NEW2_TEMP_STANDBY_DISPLAY: {
+        FanAttributes.LABEL: FanAttributes.TEMP_IN_STANDBY,
+        CONF_ENTITY_CATEGORY: EntityCategory.CONFIG,
+        SWITCH_ON: 1,
+        SWITCH_OFF: 0,
+    },
     PhilipsApi.NEW2_STANDBY_SENSORS: {
         FanAttributes.LABEL: FanAttributes.STANDBY_SENSORS,
         SWITCH_ON: 1,
@@ -1014,6 +1043,16 @@ SELECT_TYPES: dict[str, SelectDescription] = {
         FanAttributes.LABEL: FanAttributes.TIMER,
         CONF_ENTITY_CATEGORY: EntityCategory.CONFIG,
         OPTIONS: PhilipsApi.TIMER2_MAP,
+    },
+    PhilipsApi.NEW2_DISPLAY_BRIGHTNESS: {
+        FanAttributes.LABEL: FanAttributes.DISPLAY_BRIGHTNESS,
+        CONF_ENTITY_CATEGORY: EntityCategory.CONFIG,
+        OPTIONS: PhilipsApi.DISPLAY_BRIGHTNESS_MAP,
+    },
+    PhilipsApi.NEW2_DISPLAY_INDICATOR: {
+        FanAttributes.LABEL: FanAttributes.DISPLAY_INDICATOR,
+        CONF_ENTITY_CATEGORY: EntityCategory.CONFIG,
+        OPTIONS: PhilipsApi.DISPLAY_INDICATOR_MAP,
     },
 }
 

--- a/custom_components/philips_airpurifier_coap/const.py
+++ b/custom_components/philips_airpurifier_coap/const.py
@@ -169,6 +169,7 @@ class FanModel(StrEnum):
     CX3120 = "CX3120"
     CX3550 = "CX3550"
     CX5120 = "CX5120"
+    CX7550 = "CX7550"
     HU1509 = "HU1509"
     HU1510 = "HU1510"
     HU4209 = "HU4209"
@@ -190,6 +191,8 @@ class PresetMode:
     SPEED_8 = "speed_8"
     SPEED_9 = "speed_9"
     SPEED_10 = "speed_10"
+    SPEED_11 = "speed_11"
+    SPEED_12 = "speed_12"
     ALLERGEN = "allergen"
     AUTO = "auto"
     AUTO_GENERAL = "auto_general"
@@ -221,6 +224,8 @@ class PresetMode:
         SPEED_8: "pap:fan_speed_button",
         SPEED_9: "pap:fan_speed_button",
         SPEED_10: "pap:fan_speed_button",
+        SPEED_11: "pap:fan_speed_button",
+        SPEED_12: "pap:fan_speed_button",
         ALLERGEN: "pap:allergen_mode",
         AUTO: "pap:auto_mode_button",
         AUTO_GENERAL: "pap:auto_mode_button",
@@ -435,6 +440,11 @@ class PhilipsApi:
     # Heater models (e.g., CX5120) use this map
     OSCILLATION_MAP4: ClassVar = {
         SWITCH_ON: 17222,
+        SWITCH_OFF: 0,
+    }
+    # CX7550 Smart Tower Fan 7000: D0320F oscillation angle, 80 = 80 degree swing
+    OSCILLATION_MAP5: ClassVar = {
+        SWITCH_ON: 80,
         SWITCH_OFF: 0,
     }
 

--- a/custom_components/philips_airpurifier_coap/philips.py
+++ b/custom_components/philips_airpurifier_coap/philips.py
@@ -2197,6 +2197,7 @@ class PhilipsCX7550(PhilipsNew2GenericFan):
     KEY_OSCILLATION: ClassVar = {
         PhilipsApi.NEW2_OSCILLATION: PhilipsApi.OSCILLATION_MAP5,
     }
+    AVAILABLE_LIGHTS: ClassVar = [PhilipsApi.NEW2_DISPLAY_BACKLIGHT4]
     AVAILABLE_SWITCHES: ClassVar = [
         PhilipsApi.NEW2_BEEP,
         PhilipsApi.NEW2_DISPLAY_TEMP_COLOR,
@@ -2204,7 +2205,6 @@ class PhilipsCX7550(PhilipsNew2GenericFan):
     ]
     AVAILABLE_SELECTS: ClassVar = [
         PhilipsApi.NEW2_TIMER2,
-        PhilipsApi.NEW2_DISPLAY_BRIGHTNESS,
         PhilipsApi.NEW2_DISPLAY_INDICATOR,
     ]
 

--- a/custom_components/philips_airpurifier_coap/philips.py
+++ b/custom_components/philips_airpurifier_coap/philips.py
@@ -2109,7 +2109,7 @@ class PhilipsCX7550(PhilipsNew2GenericFan):
     firmware 0.2.9):
       - Power:       D03102 (0/1)
       - Manual mode: D0310A = 1
-      - Fan speed:   D0310C = 1..12 (D0310D mirrors the actual speed)
+      - Fan speed:   D0310C = speeds 1..10, plus 81 (speed 11) and 82 (speed 12); D0310D mirrors the actual speed
       - Oscillation: D0320F (0 = off, 80 = 80 degree swing)
       - Modes via D0310C (MODE_B): 0 = Auto, -126 = Natural, 17 = Sleep
     This model has no Turbo mode.
@@ -2186,12 +2186,12 @@ class PhilipsCX7550(PhilipsNew2GenericFan):
         PresetMode.SPEED_11: {
             PhilipsApi.NEW2_POWER: 1,
             PhilipsApi.NEW2_MODE_A: 1,
-            PhilipsApi.NEW2_MODE_B: 11,
+            PhilipsApi.NEW2_MODE_B: 81,
         },
         PresetMode.SPEED_12: {
             PhilipsApi.NEW2_POWER: 1,
             PhilipsApi.NEW2_MODE_A: 1,
-            PhilipsApi.NEW2_MODE_B: 12,
+            PhilipsApi.NEW2_MODE_B: 82,
         },
     }
     KEY_OSCILLATION: ClassVar = {

--- a/custom_components/philips_airpurifier_coap/philips.py
+++ b/custom_components/philips_airpurifier_coap/philips.py
@@ -2197,6 +2197,16 @@ class PhilipsCX7550(PhilipsNew2GenericFan):
     KEY_OSCILLATION: ClassVar = {
         PhilipsApi.NEW2_OSCILLATION: PhilipsApi.OSCILLATION_MAP5,
     }
+    AVAILABLE_SWITCHES: ClassVar = [
+        PhilipsApi.NEW2_BEEP,
+        PhilipsApi.NEW2_DISPLAY_TEMP_COLOR,
+        PhilipsApi.NEW2_TEMP_STANDBY_DISPLAY,
+    ]
+    AVAILABLE_SELECTS: ClassVar = [
+        PhilipsApi.NEW2_TIMER2,
+        PhilipsApi.NEW2_DISPLAY_BRIGHTNESS,
+        PhilipsApi.NEW2_DISPLAY_INDICATOR,
+    ]
 
 
 class PhilipsHU1509(PhilipsNew2GenericFan):

--- a/custom_components/philips_airpurifier_coap/philips.py
+++ b/custom_components/philips_airpurifier_coap/philips.py
@@ -2102,6 +2102,103 @@ class PhilipsCX3550(PhilipsNew2GenericFan):
     AVAILABLE_SELECTS: ClassVar = [PhilipsApi.NEW2_TIMER2]
 
 
+class PhilipsCX7550(PhilipsNew2GenericFan):
+    """CX7550 - Smart Tower Fan 7000 series.
+
+    Reverse-engineered from the local CoAP interface (device type "Babel",
+    firmware 0.2.9):
+      - Power:       D03102 (0/1)
+      - Manual mode: D0310A = 1
+      - Fan speed:   D0310C = 1..12 (D0310D mirrors the actual speed)
+      - Oscillation: D0320F (0 = off, 80 = 80 degree swing)
+      - Modes via D0310C (MODE_B): 0 = Auto, -126 = Natural, 17 = Sleep
+    This model has no Turbo mode.
+    """
+
+    AVAILABLE_PRESET_MODES: ClassVar = {
+        PresetMode.AUTO: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 0,
+        },
+        PresetMode.NATURAL: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: -126,
+        },
+        PresetMode.SLEEP: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 17,
+        },
+    }
+    AVAILABLE_SPEEDS: ClassVar = {
+        PresetMode.SPEED_1: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 1,
+        },
+        PresetMode.SPEED_2: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 2,
+        },
+        PresetMode.SPEED_3: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 3,
+        },
+        PresetMode.SPEED_4: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 4,
+        },
+        PresetMode.SPEED_5: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 5,
+        },
+        PresetMode.SPEED_6: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 6,
+        },
+        PresetMode.SPEED_7: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 7,
+        },
+        PresetMode.SPEED_8: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 8,
+        },
+        PresetMode.SPEED_9: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 9,
+        },
+        PresetMode.SPEED_10: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 10,
+        },
+        PresetMode.SPEED_11: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 11,
+        },
+        PresetMode.SPEED_12: {
+            PhilipsApi.NEW2_POWER: 1,
+            PhilipsApi.NEW2_MODE_A: 1,
+            PhilipsApi.NEW2_MODE_B: 12,
+        },
+    }
+    KEY_OSCILLATION: ClassVar = {
+        PhilipsApi.NEW2_OSCILLATION: PhilipsApi.OSCILLATION_MAP5,
+    }
+
+
 class PhilipsHU1509(PhilipsNew2GenericFan):
     """HU1509."""
 
@@ -2274,6 +2371,7 @@ model_to_class = {
     FanModel.CX3120: PhilipsCX3120,
     FanModel.CX5120: PhilipsCX5120,
     FanModel.CX3550: PhilipsCX3550,
+    FanModel.CX7550: PhilipsCX7550,
     FanModel.HU1509: PhilipsHU1510,
     FanModel.HU1510: PhilipsHU1510,
     FanModel.HU4209: PhilipsHU4210,

--- a/custom_components/philips_airpurifier_coap/translations/de.json
+++ b/custom_components/philips_airpurifier_coap/translations/de.json
@@ -210,6 +210,12 @@
       },
       "quickdry_mode": {
         "name": "Manueller QuickDry-Modus"
+      },
+      "temp_color": {
+        "name": "Temperaturfarbe anzeigen"
+      },
+      "temp_in_standby": {
+        "name": "Temperatur im Standby anzeigen"
       }
     },
     "light": {
@@ -263,6 +269,21 @@
         "state": {
           "off": "Aus",
           "on": "An"
+        }
+      },
+      "display_brightness": {
+        "name": "Display-Helligkeit",
+        "state": {
+          "off": "Aus",
+          "low": "Niedrig",
+          "high": "Hell"
+        }
+      },
+      "display_indicator": {
+        "name": "Anzeigeindikator",
+        "state": {
+          "temperature": "Temperatur (immer)",
+          "fan_speed": "Lüftergeschwindigkeit (manuell)"
         }
       }
     },

--- a/custom_components/philips_airpurifier_coap/translations/de.json
+++ b/custom_components/philips_airpurifier_coap/translations/de.json
@@ -271,14 +271,6 @@
           "on": "An"
         }
       },
-      "display_brightness": {
-        "name": "Display-Helligkeit",
-        "state": {
-          "off": "Aus",
-          "low": "Niedrig",
-          "high": "Hell"
-        }
-      },
       "display_indicator": {
         "name": "Anzeigeindikator",
         "state": {

--- a/custom_components/philips_airpurifier_coap/translations/en.json
+++ b/custom_components/philips_airpurifier_coap/translations/en.json
@@ -226,6 +226,12 @@
       },
       "quickdry_mode": {
         "name": "Quickdry mode"
+      },
+      "temp_color": {
+        "name": "Show temperature colour"
+      },
+      "temp_in_standby": {
+        "name": "Show temperature in standby"
       }
     },
     "light": {
@@ -279,6 +285,21 @@
         "state": {
           "off": "Off",
           "on": "On"
+        }
+      },
+      "display_brightness": {
+        "name": "Display brightness",
+        "state": {
+          "off": "Off",
+          "low": "Low",
+          "high": "High"
+        }
+      },
+      "display_indicator": {
+        "name": "Display indicator",
+        "state": {
+          "temperature": "Temperature (always)",
+          "fan_speed": "Fan speed (manual)"
         }
       }
     },

--- a/custom_components/philips_airpurifier_coap/translations/en.json
+++ b/custom_components/philips_airpurifier_coap/translations/en.json
@@ -287,14 +287,6 @@
           "on": "On"
         }
       },
-      "display_brightness": {
-        "name": "Display brightness",
-        "state": {
-          "off": "Off",
-          "low": "Low",
-          "high": "High"
-        }
-      },
       "display_indicator": {
         "name": "Display indicator",
         "state": {


### PR DESCRIPTION
## Summary

Adds support for the **Philips Smart Tower Fan 7000 series (CX7550/01)**.

This is a newer device that reports `type: "Babel"` and was not recognized by the integration (`model_unsupported` / "incompatible device"). It is *not* a cloud-only Air+ device — it speaks the same encrypted local CoAP / `NEW2` protocol as the existing CX tower fans, so it slots in as a `PhilipsNew2GenericFan` subclass.

## How it was mapped

Reverse-engineered against a real CX7550/01 (firmware `0.2.9`) by decrypting `/sys/dev/status` and diffing the reported keys while toggling each function:

| Function | Key | Values |
|---|---|---|
| Power | `D03102` | 0 / 1 |
| Manual mode | `D0310A` | 1 |
| Fan speed | `D0310C` (MODE_B) | 1..12 (`D0310D` mirrors the actual speed) |
| Oscillation | `D0320F` | 0 = off, 80 = 80° swing |
| Auto | `D0310C` | 0 |
| Natural | `D0310C` | -126 |
| Sleep | `D0310C` | 17 |
| Beep (switch) | `D03130` | 100 / 0 |
| Show temp colour (switch) | `D03104` | 100 / 0 |
| Show temp in standby (switch) | `D03133` | 1 / 0 |
| Display brightness (select) | `D03105` | 0 = off, 115 = low, 123 = high |
| Timer (select) | `D03110` | TIMER2_MAP (1h..12h) |
| Display indicator (select) | `D0312A` | 7 = fan speed (manual), 5 = temperature |

The fan has 12 speeds (hence new `PresetMode.SPEED_11/12`) and no Turbo mode.

## Changes
- `const.py`: `FanModel.CX7550`, `OSCILLATION_MAP5`, `PresetMode.SPEED_11/12`, new PhilipsApi keys + option maps, `SWITCH_TYPES`/`SELECT_TYPES` entries
- `philips.py`: `PhilipsCX7550` class (12 speeds, Auto/Natural/Sleep presets, oscillation, 3 switches, 3 selects) + `model_to_class` registration
- `translations/en.json`, `translations/de.json`: names + option states for the new entities
- `README.md`: CX7550 added to supported models

## Testing
Running live on a CX7550/01: power, all 12 speeds, oscillation, the three presets and all six config entities (beep, temp colour, temp-in-standby, brightness, timer, indicator) read back and control correctly. Subject to the same known CoAP flakiness as other models (the status endpoint can stay silent until the device is "warm", so the very first pairing may need a retry).