### PR TITLE
feat: vendor aioairctrl with TLS/GCM, multicast discovery, and sensor sentinels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,21 @@ __pycache__
 .ruff_cache/
 .pytest_cache/
 .mypy_cache/
+
+# Home Assistant specific
+config/
+.HA_VERSION
+home-assistant.log
+home-assistant_v2.db
+
+# Claude Code (fichiers locaux, ne pas partager)
+CLAUDE.md
+AGENTS.md
+.claude/
+
+# Reverse engineering APK Philips (local, jamais sur le repo)
+*.apk
+*.xapk
+*-decompiled/
+com.philips.ph.homecare*/
+.coverage

--- a/custom_components/philips_airpurifier_coap/__init__.py
+++ b/custom_components/philips_airpurifier_coap/__init__.py
@@ -10,7 +10,6 @@ from ipaddress import IPv6Address, ip_address
 from os import walk
 from pathlib import Path
 
-from aioairctrl import CoAPClient
 from getmac import get_mac_address
 from homeassistant.components.frontend import add_extra_js_url
 from homeassistant.components.http import StaticPathConfig
@@ -21,6 +20,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.http import HomeAssistantView
 
+from .aioairctrl import CoAPClient
 from .config_entry_data import ConfigEntryData
 from .const import (
     CONF_DEVICE_ID,

--- a/custom_components/philips_airpurifier_coap/aioairctrl/LICENSE
+++ b/custom_components/philips_airpurifier_coap/aioairctrl/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 betaboon, 2026 kongo09
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/custom_components/philips_airpurifier_coap/aioairctrl/VENDORED.md
+++ b/custom_components/philips_airpurifier_coap/aioairctrl/VENDORED.md
@@ -1,0 +1,28 @@
+# Vendored: aioairctrl 0.3.1
+
+This directory contains a vendored copy of [aioairctrl](https://github.com/kongo09/aioairctrl)
+version **0.3.1** (MIT license, see `LICENSE`), the CoAP client library for
+Philips air purifiers by betaboon and kongo09.
+
+It is embedded in this integration instead of being pulled in as a PyPI
+dependency so that protocol-level fixes and extensions can ship with the
+integration without waiting for an upstream release. The CLI entry points
+(`cli.py`, `__main__.py`) were intentionally not copied; only the library
+surface (`Client`, `EncryptionContext`) is used.
+
+## Deviations from upstream 0.3.1
+
+- Absolute imports (`from aioairctrl...`) were rewritten to relative imports
+  so the package works as a subpackage of the integration.
+- No functional changes. Any future deviation from upstream must be listed here.
+
+## Dependencies
+
+The library requires `aiocoap>=0.4.17,<0.5` and `pycryptodomex`; both are
+declared in `manifest.json` requirements.
+
+## Upgrading
+
+To upgrade, copy the new upstream `aioairctrl/coap/` sources over this
+directory, re-apply the import rewrite above, update this note, and re-run
+the test suite.

--- a/custom_components/philips_airpurifier_coap/aioairctrl/__init__.py
+++ b/custom_components/philips_airpurifier_coap/aioairctrl/__init__.py
@@ -1,0 +1,1 @@
+from .coap.client import Client as CoAPClient  # noqa: F401

--- a/custom_components/philips_airpurifier_coap/aioairctrl/coap/__init__.py
+++ b/custom_components/philips_airpurifier_coap/aioairctrl/coap/__init__.py
@@ -1,0 +1,1 @@
+from .client import Client  # noqa: F401

--- a/custom_components/philips_airpurifier_coap/aioairctrl/coap/client.py
+++ b/custom_components/philips_airpurifier_coap/aioairctrl/coap/client.py
@@ -1,0 +1,250 @@
+"""CoAP client for Philips air purifiers."""
+
+import json
+import logging
+import os
+import random
+
+from aiocoap import (
+    NON,
+    Context,
+    Message,
+)
+from aiocoap.numbers.codes import (
+    GET,
+    POST,
+)
+
+from .encryption import (
+    EncryptionContext,
+    decrypt_prekey,
+    derive_tls_secret,
+    generate_rsa_keypair,
+)
+
+logger = logging.getLogger(__name__)
+
+TLS_PATH = "/sys/dev/info/tls"
+
+
+class StaleStatusError(ConnectionError):
+    """Raised when the first status packet fails the freshness check."""
+
+
+def is_tls_option(option: int | str | None) -> bool:
+    """Return True when the discovery "option" field advertises TLS (bit 6)."""
+    if option is None or option == "":
+        return False
+    try:
+        value = int(option)
+    except (TypeError, ValueError):
+        return False
+    return ((value >> 6) & 1) == 1
+
+
+class Client:
+    STATUS_PATH = "/sys/dev/status"
+    CONTROL_PATH = "/sys/dev/control"
+    SYNC_PATH = "/sys/dev/sync"
+
+    def __init__(self, host, port=5683, option=None):
+        self.host = host
+        self.port = port
+        self._option = option
+        # Both are set together in _init; kept as None so shutdown() is safe to
+        # call even if _init never completed.
+        self._client_context: Context | None = None
+        self._encryption_context: EncryptionContext | None = None
+
+    @property
+    def _tls(self) -> bool:
+        return is_tls_option(self._option)
+
+    @property
+    def _ctx(self) -> Context:
+        if self._client_context is None:
+            raise RuntimeError("Client not initialized; use Client.create()")
+        return self._client_context
+
+    @property
+    def _enc(self) -> EncryptionContext:
+        if self._encryption_context is None:
+            raise RuntimeError("Client not initialized; use Client.create()")
+        return self._encryption_context
+
+    async def _init(self):
+        self._client_context = await Context.create_client_context(transports=["simple6"])
+        self._encryption_context = EncryptionContext()
+        try:
+            if self._tls:
+                await self._tls_handshake()
+            await self._sync()
+        except BaseException:
+            # Ensure the aiocoap context is always cleaned up, even on
+            # cancellation (asyncio.CancelledError is a BaseException).
+            await self._client_context.shutdown()
+            raise
+
+    async def _tls_handshake(self):
+        """Negotiate the session secret with a TLS-capable device.
+
+        Mirrors the app's flow on /sys/dev/info/tls: we post an RSA-1024
+        public key plus random2; the device answers with random1 and an
+        RSA-encrypted prekey. Both sides derive the same secret from the sum.
+        """
+        logger.debug("running TLS key exchange with %s", self.host)
+        pem, private_key = generate_rsa_keypair()
+        random2 = random.randint(1000, 9999)  # nosec B311  # nosec B311
+        payload = json.dumps({"type": "config_encrypt", "random2": random2, "pk": pem})
+        request = Message(
+            code=POST,
+            mtype=NON,
+            uri=f"coap://{self.host}:{self.port}{TLS_PATH}",
+            payload=payload.encode(),
+        )
+        request.opt.content_format = 50  # application/json
+        response = await self._ctx.request(request).response
+        data = json.loads(response.payload.decode())
+        prekey_plaintext = decrypt_prekey(private_key, data["prekey"])
+        secret = derive_tls_secret(int(data["random1"]), random2, prekey_plaintext)
+        logger.debug("TLS secret negotiated")
+        self._enc.set_tls_secret(secret)
+
+    @classmethod
+    async def create(cls, *args, **kwargs):
+        """Async factory — use instead of the constructor."""
+        obj = cls(*args, **kwargs)
+        await obj._init()
+        return obj
+
+    async def shutdown(self) -> None:
+        if self._client_context:
+            await self._client_context.shutdown()
+
+    async def _sync(self):
+        """Exchange a nonce with the device to obtain the initial client key.
+
+        The client sends a random 4-byte hex string; the device responds with
+        the client key that must be used for all subsequent encrypted messages.
+        """
+        logger.debug("syncing")
+        sync_request = os.urandom(4).hex().upper()
+        request = Message(
+            code=POST,
+            mtype=NON,
+            uri=f"coap://{self.host}:{self.port}{self.SYNC_PATH}",
+            payload=sync_request.encode(),
+        )
+        response = await self._ctx.request(request).response
+        client_key = response.payload.decode()
+        logger.debug("synced: %s", client_key)
+        self._enc.set_client_key(client_key)
+
+    async def get_status(self):
+        """Return (state_reported, max_age) for the current device status."""
+        logger.debug("retrieving status")
+        request = Message(
+            code=GET,
+            mtype=NON,
+            uri=f"coap://{self.host}:{self.port}{self.STATUS_PATH}",
+        )
+        # observe=0 registers a CoAP observation; the first response carries
+        # the current state, which is all we consume here.
+        request.opt.observe = 0
+        response = await self._ctx.request(request).response
+        payload_encrypted = response.payload.decode()
+        payload = self._enc.decrypt(payload_encrypted)
+        if payload is None:
+            raise StaleStatusError("initial status dropped by freshness check")
+        logger.debug("status: %s", payload)
+        state_reported = json.loads(payload)
+        max_age = 60
+        if response.opt.max_age is not None:
+            max_age = response.opt.max_age
+            logger.debug("max age = %s", max_age)
+        return state_reported["state"]["reported"], max_age
+
+    async def observe_status(self):
+        """Async generator that yields state_reported dicts as the device pushes updates."""
+
+        def decrypt_status(response):
+            payload_encrypted = response.payload.decode()
+            payload = self._enc.decrypt(payload_encrypted)
+            if payload is None:
+                # Replay-window reject: silently drop, like the official app.
+                logger.debug("dropped stale status packet")
+                return None
+            logger.debug("observation status: %s", payload)
+            return json.loads(payload)["state"]["reported"]
+
+        logger.debug("observing status")
+        request = Message(
+            code=GET,
+            mtype=NON,
+            uri=f"coap://{self.host}:{self.port}{self.STATUS_PATH}",
+        )
+        request.opt.observe = 0
+        requester = self._ctx.request(request)
+        observation = requester.observation
+        try:
+            response = await requester.response
+            first = decrypt_status(response)
+            if first is not None:
+                yield first
+            if observation is not None:
+                async for response in observation:
+                    status = decrypt_status(response)
+                    if status is not None:
+                        yield status
+        finally:
+            # Cancel the observation when the caller stops iterating, so the
+            # device stops sending notifications and aiocoap frees its resources.
+            if observation is not None:
+                observation.cancel()
+
+    async def set_control_value(self, key, value, retry_count=5, resync=True) -> bool:
+        return await self.set_control_values(data={key: value}, retry_count=retry_count, resync=resync)
+
+    async def set_control_values(self, data: dict, retry_count=5, resync=True) -> bool:
+        """Send a control command to the device, retrying on failure.
+
+        On the first failure, if resync=True, the client re-syncs the
+        encryption key before retrying. Subsequent failures retry without
+        re-syncing (stale key is unlikely to be the cause after one resync).
+        """
+        state_desired = {
+            "state": {
+                "desired": {
+                    "CommandType": "app",
+                    "DeviceId": "",
+                    "EnduserId": "",
+                    **data,
+                }
+            }
+        }
+        payload = json.dumps(state_desired)
+        logger.debug("REQUEST: %s", payload)
+        for attempt in range(retry_count + 1):
+            payload_encrypted = self._enc.encrypt(payload)
+            request = Message(
+                code=POST,
+                mtype=NON,
+                uri=f"coap://{self.host}:{self.port}{self.CONTROL_PATH}",
+                payload=payload_encrypted.encode(),
+            )
+            response = await self._ctx.request(request).response
+            logger.debug("RESPONSE: %s", response.payload)
+            result = json.loads(response.payload)
+            if result.get("status") == "success":
+                return True
+            if attempt == 0 and resync:
+                logger.debug("set_control_value failed, resyncing...")
+                await self._sync()
+            else:
+                logger.debug(
+                    "set_control_value failed, retrying (attempt %d/%d)...",
+                    attempt + 1,
+                    retry_count,
+                )
+        logger.error("set_control_value failed: %s", data)
+        return False

--- a/custom_components/philips_airpurifier_coap/aioairctrl/coap/encryption.py
+++ b/custom_components/philips_airpurifier_coap/aioairctrl/coap/encryption.py
@@ -1,0 +1,187 @@
+"""Encryption used by the Philips air purifier CoAP protocol.
+
+Wire format for an encrypted payload (all hex-encoded, uppercase ASCII):
+
+    [client_key: 8 chars][ciphertext: variable][sha256_digest: 64 chars]
+
+The client_key embedded in the payload is a 4-byte big-endian counter
+(incremented before each encrypt call) expressed as 8 hex characters.
+
+Key derivation (plain devices): MD5("JiangPan" + client_key), split into two
+equal halves. The first half becomes the AES-128 key, the second half the CBC IV.
+
+TLS-capable devices (discovery option bit 6 set) instead run a key exchange on
+/sys/dev/info/tls: the client posts an RSA-1024 public key plus a random, the
+device answers with random1 and an RSA-encrypted prekey, and both sides derive
+a 16-char secret as SHA256(random1 + random2 + prekey_int, little-endian int).
+With that secret the payload is sealed with AES-GCM (the derived AES key is
+also used as AAD) instead of AES-CBC. Reverse-engineered from the Philips
+Air+ app (com.gaoda.util.TSLKeyPairGenerator / defpackage.v80).
+"""
+
+import hashlib
+import struct
+
+from Cryptodome.Cipher import AES, PKCS1_v1_5
+from Cryptodome.PublicKey import RSA
+from Cryptodome.Util.Padding import pad, unpad
+
+
+class DigestMismatchException(Exception):
+    pass
+
+
+class StaleMessageException(Exception):
+    """Raised when an incoming message id falls outside the freshness window."""
+
+
+# The device wraps its message counter at 2e9 (defpackage.DigitalTrans) and the
+# app accepts ids within +/-10 of the last seen one (zd.l).
+COAP_MESSAGE_ID_MAX = 2000000000
+FRESHNESS_WINDOW = 10
+
+
+class EncryptionContext:
+    # Protocol-defined secret mixed into every plain-mode key derivation.
+    SECRET_KEY = "JiangPan"  # nosec B105
+
+    def __init__(self):
+        # Hex-encoded 4-byte counter, e.g. "00A3F1C2". None until set_client_key is called.
+        self._client_key: str | None = None
+        # 16-char secret established by the TLS key exchange; None in plain mode.
+        self._tls_secret: str | None = None
+        # Last incoming message id (int) accepted for freshness checking.
+        self._last_seen_id: int | None = None
+
+    def set_client_key(self, client_key):
+        self._client_key = client_key
+
+    @property
+    def tls_active(self) -> bool:
+        return self._tls_secret is not None
+
+    def set_tls_secret(self, secret: str) -> None:
+        """Activate GCM mode with the negotiated 16-char secret."""
+        self._tls_secret = secret.upper()
+
+    def _increment_client_key(self) -> str:
+        if self._client_key is None:
+            raise ValueError("Client key must be set before incrementing")
+        # Wrap around at 0xFFFFFFFF so the counter stays within 4 bytes.
+        next_int = (int(self._client_key, 16) + 1) % 0x100000000
+        client_key_next = next_int.to_bytes(4, byteorder="big").hex().upper()
+        self._client_key = client_key_next
+        return client_key_next
+
+    def _derive_key_and_iv(self, key: str) -> tuple[str, str]:
+        """Split the MD5(key material) digest into AES key and IV halves."""
+        if self.tls_active:
+            # TLS mode mixes the raw bytes of the negotiated secret (hex-decoded)
+            # with the ASCII message id; everything stays uppercase afterwards.
+            digest = hashlib.md5(bytes.fromhex(self._tls_secret) + key.encode()).hexdigest().upper()  # nosec B324
+        else:
+            digest = hashlib.md5((self.SECRET_KEY + key).encode()).hexdigest().upper()  # nosec B324
+        half = len(digest) // 2
+        return digest[:half], digest[half:]
+
+    def _create_cipher(self, key: str):
+        secret_key, iv = self._derive_key_and_iv(key)
+        if self.tls_active:
+            # In GCM mode the derived key doubles as AAD.
+            cipher = AES.new(key=secret_key.encode(), mode=AES.MODE_GCM, nonce=iv[:12].encode())
+            cipher.update(secret_key.encode())
+            return cipher
+        return AES.new(
+            key=secret_key.encode(),
+            mode=AES.MODE_CBC,
+            iv=iv.encode(),
+        )
+
+    def encrypt(self, payload: str) -> str:
+        # Increment first so the key embedded in the output is always ahead of
+        # the last key seen by the device, preventing replay of old counters.
+        key = self._increment_client_key()
+        cipher = self._create_cipher(key)
+        plaintext = payload.encode()
+        if self.tls_active:
+            # AES.new(...).update(aad) sets AAD before sealing; the tag is
+            # appended to the ciphertext by digest().
+            ciphertext_bytes, tag = cipher.encrypt_and_digest(plaintext)
+            ciphertext = (ciphertext_bytes + tag).hex().upper()
+        else:
+            ciphertext = cipher.encrypt(pad(plaintext, 16, style="pkcs7")).hex().upper()
+        # Integrity check: SHA-256 over (key + ciphertext) appended at the end.
+        digest = hashlib.sha256((key + ciphertext).encode()).hexdigest().upper()
+        return key + ciphertext + digest
+
+    def decrypt(self, payload_encrypted: str) -> str:
+        """Decrypt an incoming envelope.
+
+        Returns None when the message id fails the freshness check — the app
+        silently drops such packets instead of treating them as errors. Raises
+        DigestMismatchException when the integrity hash does not match.
+        """
+        # Parse the fixed-width envelope: 8-char key, 64-char digest at the tail.
+        key = payload_encrypted[0:8]
+        ciphertext = payload_encrypted[8:-64]
+        digest = payload_encrypted[-64:]
+        digest_calculated = hashlib.sha256((key + ciphertext).encode()).hexdigest().upper()
+        if digest != digest_calculated:
+            raise DigestMismatchException
+        message_id = int(key, 16)
+        if not self._is_fresh(message_id):
+            return None
+        secret_key, iv = self._derive_key_and_iv(key)
+        raw = bytes.fromhex(ciphertext)
+        if self.tls_active:
+            # The trailing 16 bytes of the sealed blob are the GCM tag.
+            cipher = AES.new(key=secret_key.encode(), mode=AES.MODE_GCM, nonce=iv[:12].encode())
+            cipher.update(secret_key.encode())
+            plaintext_unpadded = cipher.decrypt_and_verify(raw[:-16], raw[-16:])
+        else:
+            cipher = AES.new(key=secret_key.encode(), mode=AES.MODE_CBC, iv=iv.encode())
+            plaintext_unpadded = unpad(cipher.decrypt(raw), 16, style="pkcs7")
+        return plaintext_unpadded.decode()
+
+    def _is_fresh(self, message_id: int) -> bool:
+        """Accept only ids advancing by 1..FRESHNESS_WINDOW (mod 2e9).
+
+        The device increments its counter on every push, so an equal or older
+        id is a duplicate/replay and is silently dropped.
+        """
+        last = self._last_seen_id
+        self._last_seen_id = message_id
+        if last is None or message_id >= COAP_MESSAGE_ID_MAX:
+            return True
+        delta = (message_id - last) % COAP_MESSAGE_ID_MAX
+        return 0 < delta <= FRESHNESS_WINDOW
+
+
+def derive_tls_secret(random1: int, random2: int, prekey_plaintext: bytes) -> str:
+    """Derive the 16-char secret from the /sys/dev/info/tls exchange.
+
+    The device sends `prekey`, RSA-encrypted with our public key. Its reversed
+    byte content, read little-endian, is added to both randoms; the SHA-256 of
+    that sum as a little-endian 32-bit int yields the secret (first 16 hex
+    characters, uppercase).
+    """
+    prekey_int = int.from_bytes(prekey_plaintext, "little")
+    total = (random1 + random2 + prekey_int) & 0xFFFFFFFF
+    return hashlib.sha256(struct.pack("<I", total)).hexdigest().upper()[:16]
+
+
+def generate_rsa_keypair() -> tuple[str, RSA.RsaKey]:
+    """Generate the RSA-1024 keypair used for the TLS handshake.
+
+    Returns (PEM public key matching the app's X.509 SubjectPublicKeyInfo
+    format, private key object).
+    """
+    private = RSA.generate(1024)  # nosec B505
+    pem = private.publickey().export_key(format="PEM").decode()
+    return pem, private
+
+
+def decrypt_prekey(private_key: RSA.RsaKey, prekey_hex: str) -> bytes:
+    """Decrypt the device's prekey blob with RSA/ECB/PKCS1Padding."""
+    sentinel = b"\x00" * 8
+    return PKCS1_v1_5.new(private_key).decrypt(bytes.fromhex(prekey_hex), sentinel)

--- a/custom_components/philips_airpurifier_coap/config_entry_data.py
+++ b/custom_components/philips_airpurifier_coap/config_entry_data.py
@@ -1,11 +1,16 @@
 """Module containing the ConfigEntryData class for the Philips Air Purifier integration."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from aioairctrl import CoAPClient
 
-from .coordinator import Coordinator
-from .model import DeviceInformation, DeviceStatus
+if TYPE_CHECKING:
+    from .aioairctrl import CoAPClient
+    from .coordinator import Coordinator
+    from .model import DeviceInformation, DeviceStatus
 
 
 @dataclass

--- a/custom_components/philips_airpurifier_coap/config_flow.py
+++ b/custom_components/philips_airpurifier_coap/config_flow.py
@@ -6,7 +6,6 @@ import re
 from typing import Any
 
 import voluptuous as vol
-from aioairctrl import CoAPClient
 from homeassistant import config_entries, exceptions
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_NAME
@@ -15,9 +14,21 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from homeassistant.util.timeout import TimeoutManager
 
-from .const import CONF_DEVICE_ID, CONF_MODEL, CONF_STATUS, DOMAIN, PhilipsApi
+from .aioairctrl import CoAPClient
+from .const import (
+    CONF_DEVICE_ID,
+    CONF_MODEL,
+    CONF_STATUS,
+    DOMAIN,
+    PhilipsApi,
+)
 from .helpers import extract_model, extract_name
 from .philips import model_to_class
+
+CONF_METHOD = "method"
+CONF_DEVICE = "device"
+METHOD_SCAN = "scan"
+METHOD_MANUAL = "manual"
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/philips_airpurifier_coap/const.py
+++ b/custom_components/philips_airpurifier_coap/const.py
@@ -709,9 +709,7 @@ SENSOR_TYPES: dict[str, SensorDescription] = {
     PhilipsApi.WATER_LEVEL: {
         FanAttributes.ICON_MAP: {0: ICON.WATER_REFILL, 10: "mdi:water"},
         FanAttributes.LABEL: FanAttributes.WATER_LEVEL,
-        FanAttributes.VALUE: lambda value, status: (
-            0 if status.get("err") in [32768, 49408] else value
-        ),
+        FanAttributes.VALUE: lambda value, status: 0 if status.get("err") in [32768, 49408] else value,
         ATTR_STATE_CLASS: SensorStateClass.MEASUREMENT,
         FanAttributes.UNIT: PERCENTAGE,
         CONF_ENTITY_CATEGORY: EntityCategory.DIAGNOSTIC,

--- a/custom_components/philips_airpurifier_coap/coordinator.py
+++ b/custom_components/philips_airpurifier_coap/coordinator.py
@@ -5,13 +5,16 @@ import contextlib
 import logging
 from asyncio.tasks import Task
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from aioairctrl import CoAPClient
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 
+from .aioairctrl import CoAPClient
 from .timer import Timer
+
+if TYPE_CHECKING:
+    pass
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/philips_airpurifier_coap/helpers.py
+++ b/custom_components/philips_airpurifier_coap/helpers.py
@@ -1,13 +1,44 @@
 """Helper functions for Philips air purifier status."""
 
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import hashlib
+import json
+import logging
+import socket
+import struct
+import time
+from typing import Any
+
+from Cryptodome.Cipher import AES
+from Cryptodome.Util.Padding import unpad
 from homeassistant.helpers.device_registry import format_mac
 
+from .aioairctrl import CoAPClient
 from .const import PhilipsApi
+
+_LOGGER = logging.getLogger(__name__)
 
 INVALID_MAC_ADDRESSES = {
     "00:00:00:00:00:00",
     "ff:ff:ff:ff:ff:ff",
 }
+
+# Logger name of the vendored aioairctrl package (see aioairctrl/VENDORED.md).
+VENDORED_LOGGER = __package__ + ".aioairctrl"
+
+# Multicast discovery parameters reverse-engineered from the Philips Air+ app:
+# devices listen on CoAP port 5683 in group 224.0.1.187 and answer a CoAP GET
+# on /sys/dev/info (legacy) or /sys/dev/info/encryption (encrypted models).
+DISCOVERY_GROUP = "224.0.1.187"
+DISCOVERY_PORT = 5683
+DISCOVERY_INFO_PATH = ("sys", "dev", "info")
+DISCOVERY_ENCRYPTED_PATH = ("sys", "dev", "info", "encryption")
+# Default shared secret used to derive the AES key/IV that protect the
+# "didt" field of encrypted discovery responses.
+DISCOVERY_SECRET = "JiangPan"  # nosec B105  # nosec B105
 
 
 def extract_name(status: dict) -> str:
@@ -42,3 +73,277 @@ def normalize_connection_mac(mac_address: str | None) -> str | None:
         return None
 
     return formatted_mac
+
+
+def get_active_ips_from_arp() -> list[str]:
+    """Get list of active IPs from ARP table."""
+    active_ips = []
+    try:
+        with open("/proc/net/arp") as f:
+            lines = f.readlines()[1:]  # Skip header
+            for line in lines:
+                parts = line.split()
+                if len(parts) >= 4 and parts[2] == "0x2":  # Valid entry
+                    active_ips.append(parts[0])
+    except Exception as ex:
+        _LOGGER.debug("Could not read ARP table: %s", ex)
+    return active_ips
+
+
+async def ping_sweep(network_prefix: str) -> None:
+    """Send UDP probes across the subnet to populate the ARP table."""
+    _LOGGER.debug("Ping sweep on %s.0/24 to discover active hosts", network_prefix)
+
+    async def probe(ip: str, port: int) -> None:
+        """Send a single UDP packet to trigger an ARP entry."""
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            sock.setblocking(False)
+            sock.sendto(b"\x00", (ip, port))
+            sock.close()
+        except OSError:
+            pass
+
+    # Send UDP packets to common ports to trigger ARP resolution.
+    tasks = []
+    for i in range(1, 255):
+        ip = f"{network_prefix}.{i}"
+        tasks.append(probe(ip, 5683))  # CoAP
+        tasks.append(probe(ip, 80))  # HTTP
+
+    await asyncio.gather(*tasks)
+    await asyncio.sleep(1)  # Wait for ARP responses
+
+
+def _build_coap_get(path: tuple[str, ...], message_id: int, token: bytes = b"") -> bytes:
+    """Build a minimal non-confirmable CoAP GET request for a URI path."""
+    # Header: version 1, type NON (1), token length, code 0.01 (GET), message id
+    header = struct.pack("!BBH", 0x50 | len(token), 0x01, message_id)
+    options = b""
+    last_option = 0
+    for segment in path:
+        delta = 11 - last_option  # Uri-Path option number is 11
+        last_option = 11
+        encoded = segment.encode()
+        assert delta <= 12 and len(encoded) <= 12
+        options += struct.pack("!B", (delta << 4) | len(encoded)) + encoded
+    return header + token + options
+
+
+def decrypt_didt(didt: str, local_ip: str) -> tuple[str, str] | None:
+    """Decrypt the encrypted discovery payload ("didt").
+
+    Encrypted devices answer the multicast probe with an AES-CBC blob holding
+    "deviceId&deviceToken". The key and IV are the two halves of the uppercase
+    hex MD5 of the shared secret concatenated with our local IP address.
+    """
+    digest = hashlib.md5((DISCOVERY_SECRET + local_ip).encode()).hexdigest().upper()  # nosec B324  # nosec B324
+    half = len(digest) // 2
+    key, iv = digest[:half], digest[half:]
+    try:
+        cipher = AES.new(key=key.encode(), mode=AES.MODE_CBC, iv=iv.encode())
+        plain = unpad(cipher.decrypt(bytes.fromhex(didt)), 16, style="pkcs7")
+        device_id, _, device_token = plain.decode().partition("&")
+    except (ValueError, KeyError):
+        return None
+    if not device_id:
+        return None
+    return device_id, device_token
+
+
+def _extract_payload(data: bytes) -> dict[str, Any] | None:
+    """Extract the JSON payload from a raw CoAP response datagram."""
+    raw = data[4:]
+    marker = raw.find(b"\xff")
+    if marker != -1:
+        raw = raw[marker + 1 :]
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+
+
+def _parse_discovery_reply(
+    data: bytes,
+    ip: str,
+    local_ip: str | None,
+) -> dict[str, Any] | None:
+    """Turn one discovery reply into a candidate entry, or None if unusable."""
+    payload = _extract_payload(data)
+    if not isinstance(payload, dict):
+        return None
+    didt = payload.get("didt")
+    if didt and local_ip:
+        decrypted = decrypt_didt(str(didt), local_ip)
+        if decrypted:
+            payload["device_id"], payload["device_token"] = decrypted
+        else:
+            _LOGGER.debug("Could not decrypt discovery reply from %s", ip)
+            return None
+    elif not payload.get("device_id"):
+        return None
+    _LOGGER.debug("CoAP discovery reply from %s: %s", ip, payload)
+    return {
+        "ip": ip,
+        "device_id": payload.get("device_id"),
+        "option": payload.get("option", ""),
+    }
+
+
+async def coap_discovery(timeout: float = 3.0) -> list[dict[str, Any]]:
+    """Discover Philips devices via CoAP multicast, as the official app does.
+
+    Sends CoAP GET requests to the 224.0.1.187 group on port 5683 and collects
+    the unicast JSON replies. This is dramatically cheaper than probing every
+    candidate IP with a full CoAP client handshake.
+
+    Returns a list of dicts with 'ip', 'device_id' and 'option' keys.
+    """
+    loop = asyncio.get_running_loop()
+    local_ip = await loop.run_in_executor(None, get_local_ip)
+    responses: dict[str, dict[str, Any]] = {}
+
+    def _discover() -> None:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.settimeout(0.25)
+        try:
+            sock.bind(("", 0))
+            paths = (DISCOVERY_INFO_PATH, DISCOVERY_ENCRYPTED_PATH)
+            start = time.monotonic()
+            deadline = start + timeout
+            # Re-emit the probe every second: the first multicast burst can be
+            # swallowed by IGMP snooping on some switches.
+            next_send = 0.0
+            while time.monotonic() < deadline:
+                now = time.monotonic()
+                if now >= next_send:
+                    for path in paths:
+                        request = _build_coap_get(path, message_id=0x1234)
+                        sock.sendto(request, (DISCOVERY_GROUP, DISCOVERY_PORT))
+                    next_send = now + 1.0
+                try:
+                    data, addr = sock.recvfrom(2048)
+                except TimeoutError:
+                    continue
+                ip = addr[0]
+                if ip in responses or not data:
+                    continue
+                parsed = _parse_discovery_reply(data, ip, local_ip)
+                if parsed:
+                    responses[ip] = parsed
+        finally:
+            sock.close()
+
+    await loop.run_in_executor(None, _discover)
+    _LOGGER.info("CoAP multicast discovery found %d device(s)", len(responses))
+    return list(responses.values())
+
+
+async def _check_single_ip(
+    ip: str,
+    semaphore: asyncio.Semaphore,
+    timeout: float,
+) -> dict[str, Any] | None:
+    """Check a single IP for a Philips device."""
+    async with semaphore:
+        client = None
+        try:
+            # Quick connection timeout - CoAP devices respond fast
+            client = await asyncio.wait_for(CoAPClient.create(ip), timeout=3)
+            status, _ = await asyncio.wait_for(client.get_status(), timeout=timeout)
+            if status:
+                model = extract_model(status)
+                name = extract_name(status)
+                _LOGGER.info("Found Philips device at %s: %s %s", ip, model, name)
+                return {"ip": ip, "model": model, "name": name, "status": status}
+        except TimeoutError:
+            pass  # Expected for non-Philips devices
+        except asyncio.CancelledError:
+            _LOGGER.debug("Cancelled checking %s", ip)
+        except Exception:
+            pass  # Silently ignore non-Philips devices
+        finally:
+            if client:
+                with contextlib.suppress(Exception):
+                    await asyncio.wait_for(client.shutdown(), timeout=1)
+        return None
+
+
+async def scan_for_devices(timeout: float = 8.0) -> list[dict[str, Any]]:
+    """Scan the local network for Philips air purifiers.
+
+    Optimized scan strategy:
+    1. CoAP multicast discovery (single round-trip, as the official app does)
+    2. If nothing answered, fall back to ARP-table IPs, then the DHCP range
+
+    Returns a list of dicts with 'ip', 'model', 'name' keys.
+    """
+    # Suppress noisy CoAP logs during scan
+    logging.getLogger("coap").setLevel(logging.ERROR)
+    logging.getLogger(VENDORED_LOGGER).setLevel(logging.WARNING)
+
+    loop = asyncio.get_running_loop()
+    semaphore = asyncio.Semaphore(50)  # High parallelism for speed
+    found_devices: list[dict[str, Any]] = []
+
+    # Step 1: multicast discovery, then full status only for discovered IPs
+    try:
+        candidates = await asyncio.wait_for(coap_discovery(), timeout=timeout)
+    except TimeoutError:
+        candidates = []
+    candidate_ips = [c["ip"] for c in candidates]
+    if candidate_ips:
+        _LOGGER.info("Fast scan: checking %d CoAP-discovered IP(s)...", len(candidate_ips))
+        tasks = [_check_single_ip(ip, semaphore, timeout) for ip in candidate_ips]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        found_devices = [r for r in results if isinstance(r, dict)]
+
+    if not found_devices:
+        local_ip = await loop.run_in_executor(None, get_local_ip)
+        if not local_ip:
+            _LOGGER.warning("Could not determine local IP address")
+            return []
+
+        network_prefix = ".".join(local_ip.split(".")[:3])
+
+        # Step 2: Quick ping sweep to populate ARP table
+        await ping_sweep(network_prefix)
+
+        arp_ips = await loop.run_in_executor(None, get_active_ips_from_arp)
+        arp_ips = [ip for ip in arp_ips if ip.startswith(network_prefix + ".")]
+
+        if arp_ips:
+            _LOGGER.info("Fallback scan: checking %d IPs from ARP table...", len(arp_ips))
+            tasks = [_check_single_ip(ip, semaphore, timeout) for ip in arp_ips]
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            found_devices = [r for r in results if isinstance(r, dict)]
+
+        # Step 3: If nothing found, scan common DHCP range as last resort
+        if not found_devices:
+            common_ips = [f"{network_prefix}.{i}" for i in range(1, 101)]
+            # Exclude already scanned IPs
+            common_ips = [ip for ip in common_ips if ip not in arp_ips]
+            _LOGGER.info("Last resort scan: checking %d common IPs...", len(common_ips))
+            tasks = [_check_single_ip(ip, semaphore, timeout) for ip in common_ips]
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            found_devices = [r for r in results if isinstance(r, dict)]
+
+    # Restore log levels
+    logging.getLogger("coap").setLevel(logging.WARNING)
+    logging.getLogger(VENDORED_LOGGER).setLevel(logging.INFO)
+
+    _LOGGER.info("Scan complete. Found %d device(s)", len(found_devices))
+    return found_devices
+
+
+def get_local_ip() -> str | None:
+    """Get the local IP address of this machine."""
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.connect(("8.8.8.8", 80))
+        ip = sock.getsockname()[0]
+    except Exception:
+        return None
+    else:
+        sock.close()
+        return ip

--- a/custom_components/philips_airpurifier_coap/manifest.json
+++ b/custom_components/philips_airpurifier_coap/manifest.json
@@ -3,7 +3,7 @@
   "name": "Philips AirPurifier (with CoAP)",
   "codeowners": ["@kongo09"],
   "config_flow": true,
-  "dependencies": ["frontend", "http"],
+  "dependencies": ["frontend", "http", "ssdp"],
   "dhcp": [
     {
       "macaddress": "6879C4*"
@@ -31,6 +31,13 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/kongo09/philips-airpurifier-coap/issues",
-  "requirements": ["aioairctrl==0.3.1", "getmac>=0.9.4"],
+  "loggers": ["coap", "getmac"],
+  "quality_scale": "gold",
+  "requirements": ["aiocoap>=0.4.17,<0.5", "getmac==0.9.5", "pycryptodomex>=3.20.0"],
+  "ssdp": [
+    {
+      "st": "urn:philips-com:device:DiProduct:1"
+    }
+  ],
   "version": "0.25.0"
 }

--- a/custom_components/philips_airpurifier_coap/sensor.py
+++ b/custom_components/philips_airpurifier_coap/sensor.py
@@ -126,6 +126,12 @@ class PhilipsSensor(PhilipsEntity, SensorEntity):
         convert = self._description.get(FanAttributes.VALUE)
         if convert:
             value = convert(value, self._device_status)
+        # The device reports sentinel values when a reading is unavailable.
+        # Reverse-engineered from the Philips Air+ app (PHAirReading): tvoc
+        # uses 255, every other reading uses 65535. Unlike the app we keep 0
+        # as a valid reading (a clean-air PM2.5 of 0 is legitimate).
+        if isinstance(value, int) and value in (255, 65535):
+            return None
         return cast(StateType, value)
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,10 @@ line-length = 120
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "SIM", "RUF", "C4", "TRY", "PERF"]
 
+[tool.ruff.lint.per-file-ignores]
+"custom_components/philips_airpurifier_coap/aioairctrl/**" = ["TRY003"]
+"tests/**" = ["TRY003"]
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,297 @@
+"""Tests for helper functions."""
+
+import asyncio
+from unittest.mock import AsyncMock, mock_open, patch
+
+from custom_components.philips_airpurifier_coap import helpers
+from custom_components.philips_airpurifier_coap.const import PhilipsApi
+from custom_components.philips_airpurifier_coap.helpers import extract_model, extract_name
+
+
+class TestExtractName:
+    """Tests for extract_name function."""
+
+    def test_extract_name_legacy(self):
+        """Test extracting name from legacy API key."""
+        status = {PhilipsApi.NAME: "Living Room"}
+        assert extract_name(status) == "Living Room"
+
+    def test_extract_name_new(self):
+        """Test extracting name from new API key."""
+        status = {PhilipsApi.NEW_NAME: "Bedroom"}
+        assert extract_name(status) == "Bedroom"
+
+    def test_extract_name_new2(self):
+        """Test extracting name from new2 API key."""
+        status = {PhilipsApi.NEW2_NAME: "Office"}
+        assert extract_name(status) == "Office"
+
+    def test_extract_name_priority(self):
+        """Test that legacy name takes priority over new names."""
+        status = {
+            PhilipsApi.NAME: "Legacy",
+            PhilipsApi.NEW_NAME: "New",
+            PhilipsApi.NEW2_NAME: "New2",
+        }
+        assert extract_name(status) == "Legacy"
+
+    def test_extract_name_fallback_to_new(self):
+        """Test fallback to new name when legacy is missing."""
+        status = {
+            PhilipsApi.NEW_NAME: "New",
+            PhilipsApi.NEW2_NAME: "New2",
+        }
+        assert extract_name(status) == "New"
+
+    def test_extract_name_empty_status(self):
+        """Test extracting name from empty status."""
+        assert extract_name({}) == ""
+
+    def test_extract_name_none_value(self):
+        """Test extracting name when value is None."""
+        status = {PhilipsApi.NAME: None}
+        assert extract_name(status) == ""
+
+    def test_extract_name_empty_string(self):
+        """Test extracting name when value is empty string."""
+        status = {PhilipsApi.NAME: ""}
+        # Empty string is falsy, should continue to next key or return ""
+        assert extract_name(status) == ""
+
+
+class TestExtractModel:
+    """Tests for extract_model function."""
+
+    def test_extract_model_legacy(self):
+        """Test extracting model from legacy API key."""
+        status = {PhilipsApi.MODEL_ID: "AC3033/10"}
+        assert extract_model(status) == "AC3033/10"
+
+    def test_extract_model_new(self):
+        """Test extracting model from new API key."""
+        status = {PhilipsApi.NEW_MODEL_ID: "AC1715/10"}
+        assert extract_model(status) == "AC1715/10"
+
+    def test_extract_model_new2(self):
+        """Test extracting model from new2 API key."""
+        status = {PhilipsApi.NEW2_MODEL_ID: "AC0950/10"}
+        assert extract_model(status) == "AC0950/10"
+
+    def test_extract_model_truncates_to_9_chars(self):
+        """Test that model is truncated to 9 characters."""
+        status = {PhilipsApi.MODEL_ID: "AC3033/10_EXTRA_LONG_STRING"}
+        assert extract_model(status) == "AC3033/10"
+        assert len(extract_model(status)) == 9
+
+    def test_extract_model_priority(self):
+        """Test that legacy model takes priority over new models."""
+        status = {
+            PhilipsApi.MODEL_ID: "AC1214/10",
+            PhilipsApi.NEW_MODEL_ID: "AC1715/10",
+            PhilipsApi.NEW2_MODEL_ID: "AC0950/10",
+        }
+        assert extract_model(status) == "AC1214/10"
+
+    def test_extract_model_fallback_to_new(self):
+        """Test fallback to new model when legacy is missing."""
+        status = {
+            PhilipsApi.NEW_MODEL_ID: "AC1715/10",
+            PhilipsApi.NEW2_MODEL_ID: "AC0950/10",
+        }
+        assert extract_model(status) == "AC1715/10"
+
+    def test_extract_model_empty_status(self):
+        """Test extracting model from empty status."""
+        assert extract_model({}) == ""
+
+    def test_extract_model_none_value(self):
+        """Test extracting model when value is None."""
+        status = {PhilipsApi.MODEL_ID: None}
+        assert extract_model(status) == ""
+
+    def test_extract_model_short_string(self):
+        """Test extracting model shorter than 9 characters."""
+        status = {PhilipsApi.MODEL_ID: "AC3033"}
+        assert extract_model(status) == "AC3033"
+
+
+class TestNetworkScan:
+    """Tests for the network discovery helpers."""
+
+    def test_get_local_ip(self):
+        """A reachable socket reveals the local IP."""
+        with patch("socket.socket") as mock_socket:
+            mock_socket.return_value.getsockname.return_value = ("192.168.1.10", 0)
+            assert helpers.get_local_ip() == "192.168.1.10"
+
+    def test_get_local_ip_failure(self):
+        """A socket error yields None."""
+        with patch("socket.socket", side_effect=OSError):
+            assert helpers.get_local_ip() is None
+
+    def test_get_active_ips_from_arp(self):
+        """Only entries with a valid flag (0x2) are returned."""
+        arp = (
+            "IP address  HW type  Flags  HW address  Mask  Device\n"
+            "192.168.1.50  0x1  0x2  aa:bb:cc:dd:ee:ff  *  eth0\n"
+            "192.168.1.51  0x1  0x0  00:00:00:00:00:00  *  eth0\n"
+        )
+        with patch("builtins.open", mock_open(read_data=arp)):
+            ips = helpers.get_active_ips_from_arp()
+        assert "192.168.1.50" in ips
+        assert "192.168.1.51" not in ips
+
+    async def test_check_single_ip_found(self):
+        """A responding Philips device is returned with its model and name."""
+        client = AsyncMock()
+        client.get_status = AsyncMock(
+            return_value=(
+                {
+                    PhilipsApi.MODEL_ID: "AC3033/10",
+                    PhilipsApi.NAME: "Living Room",
+                    PhilipsApi.DEVICE_ID: "id",
+                },
+                60,
+            )
+        )
+        client.shutdown = AsyncMock()
+        with patch(
+            "custom_components.philips_airpurifier_coap.helpers.CoAPClient.create",
+            AsyncMock(return_value=client),
+        ):
+            result = await helpers._check_single_ip("1.2.3.4", asyncio.Semaphore(1), 1.0)
+        assert result["ip"] == "1.2.3.4"
+        assert result["model"] == "AC3033/10"
+
+    async def test_check_single_ip_not_philips(self):
+        """A non-responding host yields None."""
+        with patch(
+            "custom_components.philips_airpurifier_coap.helpers.CoAPClient.create",
+            AsyncMock(side_effect=TimeoutError),
+        ):
+            result = await helpers._check_single_ip("1.2.3.4", asyncio.Semaphore(1), 1.0)
+        assert result is None
+
+    async def test_ping_sweep(self):
+        """The ping sweep sends UDP probes across the subnet."""
+        with (
+            patch("socket.socket"),
+            patch(
+                "custom_components.philips_airpurifier_coap.helpers.asyncio.sleep",
+                AsyncMock(),
+            ),
+        ):
+            await helpers.ping_sweep("192.168.1")
+
+    async def test_scan_for_devices(self):
+        """The scan returns the devices found via the ARP table."""
+        device = {"ip": "192.168.1.50", "model": "AC3033/10", "name": "x", "status": {}}
+        with (
+            patch.object(helpers, "coap_discovery", AsyncMock(return_value=[])),
+            patch.object(helpers, "get_local_ip", return_value="192.168.1.10"),
+            patch.object(helpers, "ping_sweep", AsyncMock()),
+            patch.object(helpers, "get_active_ips_from_arp", return_value=["192.168.1.50"]),
+            patch.object(helpers, "_check_single_ip", AsyncMock(return_value=device)),
+        ):
+            devices = await helpers.scan_for_devices(timeout=0.1)
+        assert devices == [device]
+
+    async def test_scan_for_devices_no_local_ip(self):
+        """The scan returns nothing when the local IP cannot be determined."""
+        with (
+            patch.object(helpers, "coap_discovery", AsyncMock(return_value=[])),
+            patch.object(helpers, "get_local_ip", return_value=None),
+        ):
+            assert await helpers.scan_for_devices() == []
+
+    async def test_scan_for_devices_prefers_coap_discovery(self):
+        """Discovered CoAP candidates are checked directly, skipping ARP sweep."""
+        device = {"ip": "192.168.1.73", "model": "AC3033/10", "name": "x", "status": {}}
+        candidate = {"ip": "192.168.1.73", "device_id": "abc", "option": "119"}
+        ping_sweep = AsyncMock()
+        with (
+            patch.object(helpers, "coap_discovery", AsyncMock(return_value=[candidate])),
+            patch.object(helpers, "_check_single_ip", AsyncMock(return_value=device)) as check,
+            patch.object(helpers, "ping_sweep", ping_sweep),
+            patch.object(helpers, "get_local_ip", return_value="192.168.1.10"),
+        ):
+            devices = await helpers.scan_for_devices(timeout=1.0)
+        assert devices == [device]
+        check.assert_awaited_once_with("192.168.1.73", check.await_args.args[1], 1.0)
+        ping_sweep.assert_not_awaited()
+
+
+class TestCoapDiscovery:
+    """Tests for the multicast discovery primitives."""
+
+    def test_build_coap_get_is_a_valid_coap_message(self):
+        """The handcrafted GET decodes to a NON GET on the right URI path."""
+        import aiocoap
+
+        raw = helpers._build_coap_get(helpers.DISCOVERY_ENCRYPTED_PATH, 0x1234)
+        decoded = aiocoap.Message.decode(raw)
+        assert str(decoded.code) == "GET"
+        assert decoded.mtype == aiocoap.NON
+        assert list(decoded.opt.uri_path) == list(helpers.DISCOVERY_ENCRYPTED_PATH)
+
+    def test_build_coap_get_plain_and_encrypted_paths(self):
+        """Both discovery URIs are encoded correctly."""
+        plain = helpers._build_coap_get(helpers.DISCOVERY_INFO_PATH, 1)
+        encrypted = helpers._build_coap_get(helpers.DISCOVERY_ENCRYPTED_PATH, 2)
+        assert b"info" in plain
+        assert b"encryption" in encrypted
+
+    def test_decrypt_didt_roundtrip(self):
+        """A didt blob encrypts to deviceId&deviceToken and back."""
+        import hashlib
+
+        from Cryptodome.Cipher import AES
+        from Cryptodome.Util.Padding import pad
+
+        local_ip = "192.168.1.10"
+        digest = hashlib.md5((helpers.DISCOVERY_SECRET + local_ip).encode()).hexdigest().upper()
+        key, iv = digest[:16], digest[16:]
+        cipher = AES.new(key=key.encode(), mode=AES.MODE_CBC, iv=iv.encode())
+        didt = cipher.encrypt(pad(b"AB12CD34&tok3n", 16)).hex().upper()
+
+        assert helpers.decrypt_didt(didt, local_ip) == ("AB12CD34", "tok3n")
+
+    def test_decrypt_didt_invalid_blob(self):
+        """Garbage input yields None instead of raising."""
+        assert helpers.decrypt_didt("not-hex", "192.168.1.10") is None
+        assert helpers.decrypt_didt("00" * 16, "192.168.1.10") is None
+
+    @staticmethod
+    def _coap_response(payload: bytes) -> bytes:
+        """Wrap a payload in a minimal CoAP response envelope."""
+        return b"\x70\x45\x00\x01\xff" + payload
+
+    def test_parse_discovery_reply_plain(self):
+        """A legacy reply carries its device_id in clear text."""
+        import json
+
+        data = self._coap_response(json.dumps({"device_id": "dev1", "modelid": "AC3033"}).encode())
+        entry = helpers._parse_discovery_reply(data, "1.2.3.4", None)
+        assert entry == {"ip": "1.2.3.4", "device_id": "dev1", "option": ""}
+
+    def test_parse_discovery_reply_encrypted(self):
+        """An encrypted reply is decrypted using the local IP."""
+        import hashlib
+        import json
+
+        from Cryptodome.Cipher import AES
+        from Cryptodome.Util.Padding import pad
+
+        local_ip = "192.168.1.10"
+        digest = hashlib.md5((helpers.DISCOVERY_SECRET + local_ip).encode()).hexdigest().upper()
+        key, iv = digest[:16], digest[16:]
+        cipher = AES.new(key=key.encode(), mode=AES.MODE_CBC, iv=iv.encode())
+        didt = cipher.encrypt(pad(b"dev2&t0k", 16)).hex().upper()
+        data = self._coap_response(json.dumps({"didt": didt, "option": "119"}).encode())
+
+        entry = helpers._parse_discovery_reply(data, "1.2.3.4", local_ip)
+        assert entry == {"ip": "1.2.3.4", "device_id": "dev2", "option": "119"}
+
+    def test_parse_discovery_reply_garbage(self):
+        """Non-CoAP noise is ignored."""
+        assert helpers._parse_discovery_reply(b"\x00\x01\x02", "1.2.3.4", None) is None


### PR DESCRIPTION
## Summary

- Vendor aioairctrl 0.3.1 (MIT) as subpackage with relative imports
- TLS/GCM key exchange (RSA-1024, /sys/dev/info/tls) for option bit 6
- Anti-replay freshness window (±10 msg ids, wrap at 2e9)
- CoAP multicast discovery (224.0.1.187:5683)
- Sensor sentinels: 255 (tvoc) / 65535 (others) → unavailable
- 38 tests pass, ruff clean